### PR TITLE
Add EKS cluster sharing between DogSTAC users (SSM + shared presets/deployments)

### DIFF
--- a/webui/backend/app/main.py
+++ b/webui/backend/app/main.py
@@ -9,7 +9,7 @@ import logging
 if not os.environ.get("AWS_PROFILE", "").strip():
     os.environ.pop("AWS_PROFILE", None)
 
-from app.routes import terraform, ssh, backend, keys, danger_zone, eks_manage, ecs_manage
+from app.routes import terraform, ssh, backend, keys, danger_zone, eks_manage, ecs_manage, cluster_share
 from app.services.credential_manager import credential_manager
 
 log_level = os.environ.get('LOG_LEVEL', 'INFO').upper()
@@ -54,6 +54,7 @@ app.include_router(keys.router)
 app.include_router(danger_zone.router)
 app.include_router(eks_manage.router)
 app.include_router(ecs_manage.router)
+app.include_router(cluster_share.router)
 
 
 @app.get("/")

--- a/webui/backend/app/models/schemas.py
+++ b/webui/backend/app/models/schemas.py
@@ -60,3 +60,40 @@ class TerraformApplyResponse(BaseModel):
 class TerraformStateResponse(BaseModel):
     resources: List[TerraformResource]
     variables: List[TerraformVariable]
+
+
+class ClusterShareRequestCreate(BaseModel):
+    cluster_name: str
+    cluster_arn: str
+    owner_prefix: str
+
+
+class ClusterShareRequestStatus(str, Enum):
+    PENDING = "pending"
+    APPROVED = "approved"
+    DENIED = "denied"
+
+
+class ClusterShareRequest(BaseModel):
+    id: str
+    requester_prefix: str
+    cluster_name: str
+    cluster_arn: str
+    owner_prefix: str
+    status: ClusterShareRequestStatus
+    created_at: str
+    updated_at: str
+
+
+class SharedCluster(BaseModel):
+    cluster_name: str
+    cluster_arn: str
+    owner_prefix: str
+    shared_at: str
+
+
+class EKSClusterInfo(BaseModel):
+    name: str
+    arn: str
+    status: str
+    owner_prefix: Optional[str] = None

--- a/webui/backend/app/routes/cluster_share.py
+++ b/webui/backend/app/routes/cluster_share.py
@@ -1,0 +1,87 @@
+import logging
+import os
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from app.models.schemas import ClusterShareRequestCreate
+from app.services.cluster_share_manager import ClusterShareManager
+
+router = APIRouter(prefix="/api/cluster-share", tags=["cluster-share"])
+logger = logging.getLogger(__name__)
+
+TERRAFORM_DIR = os.environ.get("TERRAFORM_DIR", "/terraform")
+share_manager = ClusterShareManager(TERRAFORM_DIR)
+
+
+@router.get("/clusters")
+async def list_eks_clusters():
+    clusters = share_manager.list_eks_clusters()
+    return {
+        "clusters": [c.model_dump() for c in clusters],
+        "my_prefix": share_manager._get_my_prefix(),
+    }
+
+
+@router.post("/requests")
+async def create_share_request(body: ClusterShareRequestCreate):
+    request = share_manager.create_request(
+        cluster_name=body.cluster_name,
+        cluster_arn=body.cluster_arn,
+        owner_prefix=body.owner_prefix,
+    )
+    if not request:
+        raise HTTPException(
+            status_code=400,
+            detail="Failed to create share request. Check that name_prefix is configured, "
+                   "you are not sharing with yourself, and no duplicate pending request exists.",
+        )
+    return request.model_dump()
+
+
+@router.get("/requests/incoming")
+async def get_incoming_requests():
+    requests = share_manager.get_incoming_requests()
+    return {"requests": [r.model_dump() for r in requests]}
+
+
+@router.get("/requests/outgoing")
+async def get_outgoing_requests():
+    requests = share_manager.get_outgoing_requests()
+    return {"requests": [r.model_dump() for r in requests]}
+
+
+@router.post("/requests/{request_id}/approve")
+async def approve_request(request_id: str):
+    result = share_manager.approve_request(request_id)
+    if not result:
+        raise HTTPException(status_code=400, detail="Failed to approve request")
+    return result.model_dump()
+
+
+@router.post("/requests/{request_id}/deny")
+async def deny_request(request_id: str):
+    result = share_manager.deny_request(request_id)
+    if not result:
+        raise HTTPException(status_code=400, detail="Failed to deny request")
+    return result.model_dump()
+
+
+@router.get("/shared")
+async def get_shared_clusters():
+    shared = share_manager.get_shared_clusters()
+    return {"clusters": [s.model_dump() for s in shared]}
+
+
+@router.get("/connected-users")
+async def get_connected_users():
+    users = share_manager.get_connected_users()
+    return {"users": users}
+
+
+@router.delete("/requests/{request_id}")
+async def delete_request(request_id: str):
+    success = share_manager.delete_request(request_id)
+    if not success:
+        raise HTTPException(status_code=400, detail="Failed to delete request")
+    return {"success": True}

--- a/webui/backend/app/routes/eks_manage.py
+++ b/webui/backend/app/routes/eks_manage.py
@@ -5,17 +5,18 @@ import logging
 import os
 import re
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import AsyncIterator, Dict, List, Optional
 
 import boto3
 from botocore.signers import RequestSigner
-from fastapi import APIRouter, HTTPException, Body
+from fastapi import APIRouter, HTTPException, Body, Query
 from fastapi.responses import StreamingResponse
 
 from app.models.schemas import ResourceType
 from app.services.credential_manager import credential_manager
-from app.services.eks_preset_manager import EKSPresetManager
+from app.services.eks_preset_manager import EKSPresetManager, S3_PRESET_PREFIX
 from app.services.terraform_parser import TerraformParser
 from app.services.terraform_runner import TerraformRunner
 from app.services.instance_discovery import get_resource_id_for_instance, get_resource_type_from_dir
@@ -185,14 +186,27 @@ def _configure_kubeconfig(cluster_name: str, region: str) -> tuple[bool, str]:
 
 
 async def _setup_kubeconfig(resource_id: Optional[str], resource_dir: Optional[Path],
-                            force: bool = False) -> tuple[bool, list[str]]:
+                            force: bool = False,
+                            explicit_cluster_name: Optional[str] = None) -> tuple[bool, list[str]]:
     lines = []
 
-    if not force and KUBECONFIG_PATH.exists() and KUBECONFIG_PATH.stat().st_size > 0:
+    if not force and not explicit_cluster_name and KUBECONFIG_PATH.exists() and KUBECONFIG_PATH.stat().st_size > 0:
         age = time.time() - KUBECONFIG_PATH.stat().st_mtime
         if age < TOKEN_EXPIRY_SECONDS:
             return True, lines
         logger.debug("Kubeconfig token expired (age=%.0fs), refreshing", age)
+
+    if explicit_cluster_name:
+        region = os.environ.get("AWS_REGION", "ap-northeast-2")
+        lines.append(f"Shared cluster: {explicit_cluster_name} (region: {region})\n")
+        lines.append("Configuring kubeconfig...\n")
+        success, output = _configure_kubeconfig(explicit_cluster_name, region)
+        lines.append(output + "\n")
+        if not success:
+            lines.append("Error: Failed to configure kubeconfig\n")
+            lines.append(f"{EXIT_SENTINEL_PREFIX}1\n")
+            return False, lines
+        return True, lines
 
     if resource_dir and resource_id:
         lines.append("Resolving EKS cluster info from Terraform outputs...\n")
@@ -296,6 +310,131 @@ async def list_presets():
     except Exception as e:
         logger.error(f"Failed to list presets: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+def _discover_owner_bucket(owner_prefix: str) -> str:
+    from app.services.config_manager import ConfigManager
+    cm = ConfigManager()
+    safe_prefix = ''.join(c if c.isalnum() or c in '-_' else '-' for c in owner_prefix)[:64]
+    ssm_path = f"/dogstac-{safe_prefix}/"
+    try:
+        ssm = boto3.client("ssm", region_name=cm._get_region())
+        response = ssm.get_parameters_by_path(Path=ssm_path, Recursive=True, MaxResults=1)
+        for param in response.get("Parameters", []):
+            parts = param["Name"].split("/")
+            if len(parts) >= 3:
+                owner_hash = parts[2]
+                safe = owner_prefix.lower().replace('_', '-')
+                safe = ''.join(c if c.isalnum() or c == '-' else '-' for c in safe)[:32]
+                bucket = f"dogstac-{safe}-{owner_hash}"
+                logger.debug(f"Discovered owner bucket via SSM: {bucket} (prefix={owner_prefix})")
+                return bucket
+    except Exception as e:
+        logger.warning(f"SSM discovery failed for {owner_prefix}: {e}")
+    bucket = cm.generate_bucket_name(owner_prefix)
+    logger.debug(f"Falling back to local hash for owner bucket: {bucket}")
+    return bucket
+
+
+def _get_owner_s3(owner_prefix: str):
+    from app.services.s3_config_manager import S3ConfigManager
+    bucket_name = _discover_owner_bucket(owner_prefix)
+    return S3ConfigManager(bucket_name)
+
+
+@router.get("/shared-presets")
+async def list_shared_presets(owner_prefix: str = Query(...)):
+    try:
+        s3 = _get_owner_s3(owner_prefix)
+        presets = []
+        files = s3.list_files(S3_PRESET_PREFIX + "/")
+        manifest_keys = [f for f in files if f.endswith("/manifest.json")]
+        for key in manifest_keys:
+            content = s3.download_text(key)
+            if content:
+                try:
+                    manifest = json.loads(content)
+                    manifest["built_in"] = manifest.get("built_in", False)
+                    presets.append(manifest)
+                except Exception:
+                    pass
+        return {"presets": presets}
+    except Exception as e:
+        logger.warning(f"Failed to list shared presets for {owner_prefix}: {e}")
+        return {"presets": []}
+
+
+@router.get("/shared-presets/{name}")
+async def get_shared_preset(name: str, owner_prefix: str = Query(...)):
+    try:
+        s3 = _get_owner_s3(owner_prefix)
+        content = s3.download_text(f"{S3_PRESET_PREFIX}/{name}/manifest.json")
+        if not content:
+            raise HTTPException(status_code=404, detail=f"Shared preset not found: {name}")
+        manifest = json.loads(content)
+        manifest["built_in"] = manifest.get("built_in", False)
+        if "files" not in manifest or not manifest["files"]:
+            all_keys = s3.list_files(f"{S3_PRESET_PREFIX}/{name}/")
+            manifest["files"] = sorted(
+                k.rsplit("/", 1)[-1] for k in all_keys
+                if not k.endswith("/") and not k.endswith("/manifest.json")
+            )
+        return manifest
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.warning(f"Failed to get shared preset {name} for {owner_prefix}: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/shared-presets/{name}/files/{filename:path}")
+async def get_shared_preset_file(name: str, filename: str, owner_prefix: str = Query(...)):
+    try:
+        s3 = _get_owner_s3(owner_prefix)
+        content = s3.download_text(f"{S3_PRESET_PREFIX}/{name}/{filename}")
+        if not content and content != "":
+            raise HTTPException(status_code=404, detail=f"File not found: {name}/{filename}")
+        return {"filename": filename, "content": content}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.warning(f"Failed to get shared preset file {name}/{filename}: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/shared-deployments")
+async def list_shared_deployments(owner_prefix: str = Query(...)):
+    try:
+        s3 = _get_owner_s3(owner_prefix)
+        content = s3.download_text(S3_PRESET_PREFIX + "/_deployments.json")
+        if content:
+            return {"deployments": json.loads(content)}
+        return {"deployments": {}}
+    except Exception as e:
+        logger.warning(f"Failed to list shared deployments for {owner_prefix}: {e}")
+        return {"deployments": {}}
+
+
+S3_DEPLOYMENTS_KEY = S3_PRESET_PREFIX + "/_deployments.json"
+
+
+def _owner_mark_deployed(name: str, owner_prefix: str):
+    s3 = _get_owner_s3(owner_prefix)
+    content = s3.download_text(S3_DEPLOYMENTS_KEY)
+    deployments = json.loads(content) if content else {}
+    deployments[name] = {"deployed_at": datetime.now(timezone.utc).isoformat()}
+    s3.upload_text(S3_DEPLOYMENTS_KEY, json.dumps(deployments, indent=2) + "\n")
+    logger.debug(f"Marked preset as deployed in owner({owner_prefix}) S3: {name}")
+
+
+def _owner_mark_undeployed(name: str, owner_prefix: str):
+    s3 = _get_owner_s3(owner_prefix)
+    content = s3.download_text(S3_DEPLOYMENTS_KEY)
+    deployments = json.loads(content) if content else {}
+    if name in deployments:
+        del deployments[name]
+        s3.upload_text(S3_DEPLOYMENTS_KEY, json.dumps(deployments, indent=2) + "\n")
+        logger.debug(f"Marked preset as undeployed in owner({owner_prefix}) S3: {name}")
 
 
 @router.get("/presets/{name}")
@@ -413,9 +552,29 @@ async def delete_preset(name: str):
     return {"success": True}
 
 
+def _sync_shared_preset_to_local(name: str, owner_prefix: str) -> Optional[Path]:
+    s3 = _get_owner_s3(owner_prefix)
+    local_dir = Path(TERRAFORM_DIR) / "eks" / name
+    local_dir.mkdir(parents=True, exist_ok=True)
+    keys = s3.list_files(f"{S3_PRESET_PREFIX}/{name}/")
+    for key in keys:
+        filename = key.rsplit("/", 1)[-1]
+        if not filename:
+            continue
+        local_path = local_dir / filename
+        content = s3.download_text(key)
+        if content or content == "":
+            local_path.write_text(content)
+    if local_dir.exists() and any(local_dir.iterdir()):
+        return local_dir
+    return None
+
+
 async def _stream_action(action_label: str, name: str, commands: List[str],
                          resource_id: Optional[str], resource_dir: Optional[Path],
-                         on_success=None) -> AsyncIterator[str]:
+                         on_success=None,
+                         explicit_cluster_name: Optional[str] = None,
+                         owner_prefix: Optional[str] = None) -> AsyncIterator[str]:
     yield f"=== EKS Preset {action_label} ===\n"
     yield f"Preset: {name}\n\n"
 
@@ -431,13 +590,21 @@ async def _stream_action(action_label: str, name: str, commands: List[str],
         yield "Syncing preset cache from S3...\n"
         await asyncio.to_thread(preset_manager.initialize_local_cache)
 
-    ok, lines = await _setup_kubeconfig(resource_id, resource_dir)
+    ok, lines = await _setup_kubeconfig(resource_id, resource_dir,
+                                         explicit_cluster_name=explicit_cluster_name)
     for line in lines:
         yield line
     if not ok:
         return
 
-    preset_dir = preset_manager.sync_preset_to_local(name)
+    if owner_prefix:
+        yield f"Syncing shared preset from {owner_prefix}...\n"
+        preset_dir = _sync_shared_preset_to_local(name, owner_prefix)
+        if not preset_dir:
+            logger.debug(f"Shared sync failed for {name}, falling back to local (OOTB)")
+            preset_dir = preset_manager.sync_preset_to_local(name)
+    else:
+        preset_dir = preset_manager.sync_preset_to_local(name)
     if not preset_dir:
         yield "Error: Failed to sync preset files to local\n"
         yield f"{EXIT_SENTINEL_PREFIX}1\n"
@@ -467,9 +634,19 @@ async def get_deployments():
         raise HTTPException(status_code=500, detail=str(e))
 
 
+def _resolve_preset(name: str, owner_prefix: Optional[str] = None) -> dict:
+    if owner_prefix:
+        s3 = _get_owner_s3(owner_prefix)
+        content = s3.download_text(f"{S3_PRESET_PREFIX}/{name}/manifest.json")
+        if content:
+            return json.loads(content)
+    return preset_manager.get_preset(name) or {}
+
+
 @router.post("/presets/{name}/deploy")
-async def deploy_preset(name: str):
-    preset = preset_manager.get_preset(name)
+async def deploy_preset(name: str, cluster_name: Optional[str] = Query(None),
+                        owner_prefix: Optional[str] = Query(None)):
+    preset = _resolve_preset(name, owner_prefix)
     if not preset:
         raise HTTPException(status_code=404, detail=f"Preset not found: {name}")
 
@@ -479,16 +656,24 @@ async def deploy_preset(name: str):
 
     resource_id, resource_dir = _get_eks_resource_info()
 
+    if owner_prefix and cluster_name:
+        on_success = lambda: _owner_mark_deployed(name, owner_prefix)
+    else:
+        on_success = lambda: preset_manager.mark_deployed(name)
+
     return StreamingResponse(
         _stream_action("Deploy", name, commands, resource_id, resource_dir,
-                        on_success=lambda: preset_manager.mark_deployed(name)),
+                        on_success=on_success,
+                        explicit_cluster_name=cluster_name,
+                        owner_prefix=owner_prefix),
         media_type="text/plain",
     )
 
 
 @router.post("/presets/{name}/update")
-async def update_preset_deploy(name: str):
-    preset = preset_manager.get_preset(name)
+async def update_preset_deploy(name: str, cluster_name: Optional[str] = Query(None),
+                               owner_prefix: Optional[str] = Query(None)):
+    preset = _resolve_preset(name, owner_prefix)
     if not preset:
         raise HTTPException(status_code=404, detail=f"Preset not found: {name}")
 
@@ -499,14 +684,17 @@ async def update_preset_deploy(name: str):
     resource_id, resource_dir = _get_eks_resource_info()
 
     return StreamingResponse(
-        _stream_action("Update", name, commands, resource_id, resource_dir),
+        _stream_action("Update", name, commands, resource_id, resource_dir,
+                        explicit_cluster_name=cluster_name,
+                        owner_prefix=owner_prefix),
         media_type="text/plain",
     )
 
 
 @router.post("/presets/{name}/undeploy")
-async def undeploy_preset(name: str):
-    preset = preset_manager.get_preset(name)
+async def undeploy_preset(name: str, cluster_name: Optional[str] = Query(None),
+                          owner_prefix: Optional[str] = Query(None)):
+    preset = _resolve_preset(name, owner_prefix)
     if not preset:
         raise HTTPException(status_code=404, detail=f"Preset not found: {name}")
 
@@ -516,22 +704,35 @@ async def undeploy_preset(name: str):
 
     resource_id, resource_dir = _get_eks_resource_info()
 
+    if owner_prefix and cluster_name:
+        on_success = lambda: _owner_mark_undeployed(name, owner_prefix)
+    else:
+        on_success = lambda: preset_manager.mark_undeployed(name)
+
     return StreamingResponse(
         _stream_action("Undeploy", name, commands, resource_id, resource_dir,
-                        on_success=lambda: preset_manager.mark_undeployed(name)),
+                        on_success=on_success,
+                        explicit_cluster_name=cluster_name,
+                        owner_prefix=owner_prefix),
         media_type="text/plain",
     )
 
 
 @router.post("/presets/{name}/force-delete")
-async def force_delete_preset(name: str):
-    preset_manager.mark_undeployed(name)
+async def force_delete_preset(name: str,
+                              cluster_name: Optional[str] = Query(None),
+                              owner_prefix: Optional[str] = Query(None)):
+    if owner_prefix and cluster_name:
+        _owner_mark_undeployed(name, owner_prefix)
+    else:
+        preset_manager.mark_undeployed(name)
     return {"success": True, "message": f"Preset '{name}' removed from deployed list"}
 
 
 @router.post("/kubectl")
 async def run_kubectl(body: dict = Body(...)):
     command = body.get("command", "").strip()
+    cluster_name = body.get("cluster_name")
     if not command:
         raise HTTPException(status_code=400, detail="command is required")
 
@@ -559,7 +760,8 @@ async def run_kubectl(body: dict = Body(...)):
     resource_id, resource_dir = _get_eks_resource_info()
 
     async def _stream():
-        ok, lines = await _setup_kubeconfig(resource_id, resource_dir)
+        ok, lines = await _setup_kubeconfig(resource_id, resource_dir,
+                                             explicit_cluster_name=cluster_name)
         for line in lines:
             yield line
         if not ok:

--- a/webui/backend/app/services/cluster_share_manager.py
+++ b/webui/backend/app/services/cluster_share_manager.py
@@ -1,0 +1,291 @@
+import json
+import logging
+import os
+import re
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+from app.models.schemas import (
+    ClusterShareRequest,
+    ClusterShareRequestStatus,
+    EKSClusterInfo,
+    SharedCluster,
+)
+
+logger = logging.getLogger(__name__)
+
+SSM_SHARE_PREFIX = "/dogstac-cluster-share/requests"
+
+
+class ClusterShareManager:
+    def __init__(self, terraform_dir: str):
+        self.terraform_dir = Path(terraform_dir)
+        self._ssm_client = None
+        self._eks_client = None
+
+    def _read_tfvar(self, key: str, default: str = "") -> str:
+        tfvars_path = self.terraform_dir / "terraform.tfvars"
+        if not tfvars_path.exists():
+            return default
+        try:
+            with open(tfvars_path, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if line and not line.startswith("#"):
+                        match = re.match(r'^(\w+)\s*=\s*(?:"([^"]*)"|(\S+))', line)
+                        if match and match.group(1) == key:
+                            return (match.group(2) or match.group(3) or "").strip() or default
+        except Exception as e:
+            logger.warning(f"Failed to read {key} from tfvars: {e}")
+        return default
+
+    def _get_region(self) -> str:
+        return self._read_tfvar("region", "ap-northeast-2")
+
+    def _get_my_prefix(self) -> str:
+        return self._read_tfvar("name_prefix", "")
+
+    @property
+    def ssm_client(self):
+        if self._ssm_client is None:
+            try:
+                self._ssm_client = boto3.client("ssm", region_name=self._get_region())
+            except Exception as e:
+                logger.warning(f"Failed to create SSM client: {e}")
+        return self._ssm_client
+
+    @property
+    def eks_client(self):
+        if self._eks_client is None:
+            try:
+                self._eks_client = boto3.client("eks", region_name=self._get_region())
+            except Exception as e:
+                logger.warning(f"Failed to create EKS client: {e}")
+        return self._eks_client
+
+    def list_eks_clusters(self) -> List[EKSClusterInfo]:
+        if not self.eks_client:
+            return []
+        try:
+            clusters: List[EKSClusterInfo] = []
+            paginator = self.eks_client.get_paginator("list_clusters")
+            for page in paginator.paginate():
+                for name in page.get("clusters", []):
+                    try:
+                        desc = self.eks_client.describe_cluster(name=name)
+                        cluster = desc.get("cluster", {})
+                        tags = cluster.get("tags", {})
+                        is_managed = tags.get("ManagedBy") == "Terraform"
+                        owner_prefix = None
+                        if is_managed:
+                            cluster_name_tag = tags.get("Name", "")
+                            if cluster_name_tag.endswith("-eks-cluster"):
+                                owner_prefix = cluster_name_tag[: -len("-eks-cluster")]
+                            elif cluster_name_tag:
+                                owner_prefix = cluster_name_tag.split("-")[0]
+                        clusters.append(EKSClusterInfo(
+                            name=name,
+                            arn=cluster.get("arn", ""),
+                            status=cluster.get("status", "UNKNOWN"),
+                            owner_prefix=owner_prefix,
+                        ))
+                    except ClientError as e:
+                        logger.warning(f"Failed to describe cluster {name}: {e}")
+            logger.debug(f"Found {len(clusters)} EKS clusters")
+            return clusters
+        except ClientError as e:
+            logger.error(f"Failed to list EKS clusters: {e}")
+            return []
+
+    def _put_request(self, request: ClusterShareRequest) -> bool:
+        if not self.ssm_client:
+            return False
+        try:
+            param_name = f"{SSM_SHARE_PREFIX}/{request.id}"
+            self.ssm_client.put_parameter(
+                Name=param_name,
+                Value=request.model_dump_json(),
+                Type="String",
+                Overwrite=True,
+                Description=f"Cluster share request from {request.requester_prefix} to {request.owner_prefix}",
+            )
+            logger.debug(f"Saved share request {request.id} to SSM")
+            return True
+        except ClientError as e:
+            logger.error(f"Failed to save share request: {e}")
+            return False
+
+    def _get_all_requests(self) -> List[ClusterShareRequest]:
+        if not self.ssm_client:
+            return []
+        try:
+            requests: List[ClusterShareRequest] = []
+            paginator = self.ssm_client.get_paginator("get_parameters_by_path")
+            for page in paginator.paginate(Path=SSM_SHARE_PREFIX, Recursive=True, MaxResults=10):
+                for param in page.get("Parameters", []):
+                    try:
+                        data = json.loads(param["Value"])
+                        requests.append(ClusterShareRequest(**data))
+                    except Exception as e:
+                        logger.warning(f"Failed to parse share request {param['Name']}: {e}")
+            return requests
+        except ClientError as e:
+            logger.error(f"Failed to list share requests: {e}")
+            return []
+
+    def _get_request_by_id(self, request_id: str) -> Optional[ClusterShareRequest]:
+        if not self.ssm_client:
+            return None
+        try:
+            param_name = f"{SSM_SHARE_PREFIX}/{request_id}"
+            response = self.ssm_client.get_parameter(Name=param_name)
+            data = json.loads(response["Parameter"]["Value"])
+            return ClusterShareRequest(**data)
+        except ClientError:
+            return None
+
+    def create_request(self, cluster_name: str, cluster_arn: str, owner_prefix: str) -> Optional[ClusterShareRequest]:
+        my_prefix = self._get_my_prefix()
+        if not my_prefix:
+            logger.error("Cannot create share request: name_prefix not configured")
+            return None
+
+        if my_prefix == owner_prefix:
+            logger.warning("Cannot share cluster with yourself")
+            return None
+
+        existing = self._get_all_requests()
+        for req in existing:
+            if (
+                req.requester_prefix == my_prefix
+                and req.cluster_arn == cluster_arn
+                and req.status == ClusterShareRequestStatus.PENDING
+            ):
+                logger.warning(f"Duplicate pending request for cluster {cluster_name}")
+                return None
+
+        now = datetime.now(timezone.utc).isoformat()
+        request = ClusterShareRequest(
+            id=str(uuid.uuid4()),
+            requester_prefix=my_prefix,
+            cluster_name=cluster_name,
+            cluster_arn=cluster_arn,
+            owner_prefix=owner_prefix,
+            status=ClusterShareRequestStatus.PENDING,
+            created_at=now,
+            updated_at=now,
+        )
+
+        if self._put_request(request):
+            logger.info(f"Created share request {request.id}: {my_prefix} -> {owner_prefix} for {cluster_name}")
+            return request
+        return None
+
+    def get_incoming_requests(self) -> List[ClusterShareRequest]:
+        my_prefix = self._get_my_prefix()
+        if not my_prefix:
+            return []
+        all_requests = self._get_all_requests()
+        return [r for r in all_requests if r.owner_prefix == my_prefix]
+
+    def get_outgoing_requests(self) -> List[ClusterShareRequest]:
+        my_prefix = self._get_my_prefix()
+        if not my_prefix:
+            return []
+        all_requests = self._get_all_requests()
+        return [r for r in all_requests if r.requester_prefix == my_prefix]
+
+    def approve_request(self, request_id: str) -> Optional[ClusterShareRequest]:
+        request = self._get_request_by_id(request_id)
+        if not request:
+            logger.warning(f"Share request {request_id} not found")
+            return None
+
+        my_prefix = self._get_my_prefix()
+        if request.owner_prefix != my_prefix:
+            logger.warning(f"Cannot approve request {request_id}: not the owner")
+            return None
+
+        if request.status != ClusterShareRequestStatus.PENDING:
+            logger.warning(f"Request {request_id} is not pending (status={request.status})")
+            return None
+
+        request.status = ClusterShareRequestStatus.APPROVED
+        request.updated_at = datetime.now(timezone.utc).isoformat()
+        if self._put_request(request):
+            logger.info(f"Approved share request {request_id}")
+            return request
+        return None
+
+    def deny_request(self, request_id: str) -> Optional[ClusterShareRequest]:
+        request = self._get_request_by_id(request_id)
+        if not request:
+            logger.warning(f"Share request {request_id} not found")
+            return None
+
+        my_prefix = self._get_my_prefix()
+        if request.owner_prefix != my_prefix:
+            logger.warning(f"Cannot deny request {request_id}: not the owner")
+            return None
+
+        if request.status != ClusterShareRequestStatus.PENDING:
+            logger.warning(f"Request {request_id} is not pending (status={request.status})")
+            return None
+
+        request.status = ClusterShareRequestStatus.DENIED
+        request.updated_at = datetime.now(timezone.utc).isoformat()
+        if self._put_request(request):
+            logger.info(f"Denied share request {request_id}")
+            return request
+        return None
+
+    def get_shared_clusters(self) -> List[SharedCluster]:
+        my_prefix = self._get_my_prefix()
+        if not my_prefix:
+            return []
+        all_requests = self._get_all_requests()
+        shared: List[SharedCluster] = []
+        for r in all_requests:
+            if r.requester_prefix == my_prefix and r.status == ClusterShareRequestStatus.APPROVED:
+                shared.append(SharedCluster(
+                    cluster_name=r.cluster_name,
+                    cluster_arn=r.cluster_arn,
+                    owner_prefix=r.owner_prefix,
+                    shared_at=r.updated_at,
+                ))
+        return shared
+
+    def get_connected_users(self) -> List[str]:
+        my_prefix = self._get_my_prefix()
+        if not my_prefix:
+            return []
+        all_requests = self._get_all_requests()
+        users = set()
+        for r in all_requests:
+            if r.owner_prefix == my_prefix and r.status == ClusterShareRequestStatus.APPROVED:
+                users.add(r.requester_prefix)
+        return sorted(users)
+
+    def delete_request(self, request_id: str) -> bool:
+        request = self._get_request_by_id(request_id)
+        if not request:
+            return False
+
+        my_prefix = self._get_my_prefix()
+        if request.requester_prefix != my_prefix and request.owner_prefix != my_prefix:
+            logger.warning(f"Cannot delete request {request_id}: not involved")
+            return False
+
+        try:
+            param_name = f"{SSM_SHARE_PREFIX}/{request_id}"
+            self.ssm_client.delete_parameter(Name=param_name)
+            logger.info(f"Deleted share request {request_id}")
+            return True
+        except ClientError as e:
+            logger.error(f"Failed to delete share request: {e}")
+            return False

--- a/webui/backend/app/services/s3_config_manager.py
+++ b/webui/backend/app/services/s3_config_manager.py
@@ -86,6 +86,32 @@ class S3ConfigManager:
             logger.error(f"Failed to list S3 objects with prefix {prefix}: {e}")
             return []
 
+    def upload_text(self, s3_key: str, text: str) -> bool:
+        if not self.s3_client:
+            logger.warning("S3 client not available")
+            return False
+        try:
+            self.s3_client.put_object(
+                Bucket=self.bucket_name,
+                Key=s3_key,
+                Body=text.encode("utf-8")
+            )
+            logger.info(f"Uploaded text to s3://{self.bucket_name}/{s3_key}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to upload text to {s3_key}: {e}")
+            return False
+
+    def download_text(self, s3_key: str) -> str:
+        if not self.s3_client:
+            return ""
+        try:
+            response = self.s3_client.get_object(Bucket=self.bucket_name, Key=s3_key)
+            return response["Body"].read().decode("utf-8")
+        except Exception as e:
+            logger.debug(f"Failed to download text from {s3_key}: {e}")
+            return ""
+
     def file_exists(self, s3_key: str) -> bool:
         if not self.s3_client:
             return False

--- a/webui/frontend/src/App.tsx
+++ b/webui/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import ConnectionsModal from './components/ConnectionsModal';
 import OnboardingModal from './components/OnboardingModal';
 import DangerZoneModal from './components/DangerZoneModal';
 import SSOLoginModal from './components/SSOLoginModal';
+import ClusterShareModal from './components/ClusterShareModal';
 import { TerraformResource, ResourceType } from './types';
 import { terraformApi as api, OnboardingStatus } from './services/api';
 
@@ -96,6 +97,8 @@ function App() {
   const [showConnectionsModal, setShowConnectionsModal] = useState(false);
   const [showOnboardingModal, setShowOnboardingModal] = useState(false);
   const [showDangerZone, setShowDangerZone] = useState(false);
+  const [showClusterShareModal, setShowClusterShareModal] = useState(false);
+  const [sharedClusterRefreshTrigger, setSharedClusterRefreshTrigger] = useState(0);
   const [onboardingStatus, setOnboardingStatus] = useState<OnboardingStatus | null>(null);
   const [resourceRefreshTrigger, setResourceRefreshTrigger] = useState(0);
   const [runningResources, setRunningResources] = useState<Map<string, string>>(new Map());
@@ -629,6 +632,8 @@ function App() {
             refreshTrigger={resourceRefreshTrigger}
             runningResources={runningResources}
             onResourcesLoaded={setResources}
+            onRequestClusterShare={() => setShowClusterShareModal(true)}
+            sharedClusterRefreshTrigger={sharedClusterRefreshTrigger}
           />
           <ActionPanel
             selectedResource={selectedResource}
@@ -670,6 +675,13 @@ function App() {
         <DangerZoneModal
           onClose={() => setShowDangerZone(false)}
           onResourcesNeedRefresh={handleResourcesNeedRefresh}
+        />
+      )}
+
+      {showClusterShareModal && (
+        <ClusterShareModal
+          onClose={() => setShowClusterShareModal(false)}
+          onSharedClustersChanged={() => setSharedClusterRefreshTrigger(prev => prev + 1)}
         />
       )}
 

--- a/webui/frontend/src/components/ActionPanel.tsx
+++ b/webui/frontend/src/components/ActionPanel.tsx
@@ -581,6 +581,15 @@ const ActionPanel = ({ selectedResource, onActionStart, onActionUpdate, onAction
             <button className="btn-help" onClick={() => setShowHelpModal(true)} title="What do these buttons do?">?</button>
           </div>
           
+          {selectedResource?.is_shared && (
+            <div className="ip-update-hint">
+              <div className="hint-icon">🔗</div>
+              <div className="hint-text">
+                Shared cluster from <strong>{selectedResource.shared_from}</strong>. You can manage workloads but cannot modify infrastructure.
+              </div>
+            </div>
+          )}
+
           {selectedResource?.type === ResourceType.SECURITY_GROUP && selectedResource?.status === 'enabled' && !runningAction && (
             <div className="ip-update-hint">
               <div className="hint-icon">💡</div>
@@ -591,7 +600,15 @@ const ActionPanel = ({ selectedResource, onActionStart, onActionUpdate, onAction
           )}
           
           <div className="action-buttons-grid">
-            {runningAction ? (
+            {selectedResource?.is_shared ? (
+              <button
+                onClick={handleEKSConnect}
+                className="btn btn-manage"
+                title="Manage shared EKS cluster workloads and presets"
+              >
+                Manage
+              </button>
+            ) : runningAction ? (
               <button
                 disabled
                 className="btn btn-stop"
@@ -682,7 +699,7 @@ const ActionPanel = ({ selectedResource, onActionStart, onActionUpdate, onAction
               </>
             )}
 
-            {selectedResource && selectedResource.type === ResourceType.SECURITY_GROUP && (
+            {selectedResource && !selectedResource.is_shared && selectedResource.type === ResourceType.SECURITY_GROUP && (
               <button
                 onClick={() => setShowSGEditor(true)}
                 className="btn btn-configure"
@@ -692,7 +709,7 @@ const ActionPanel = ({ selectedResource, onActionStart, onActionUpdate, onAction
               </button>
             )}
 
-            {selectedResource && selectedResource.type === ResourceType.EKS && (
+            {selectedResource && !selectedResource.is_shared && selectedResource.type === ResourceType.EKS && (
               <button
                 onClick={() => setShowEKSEditor(true)}
                 className="btn btn-configure"
@@ -702,7 +719,7 @@ const ActionPanel = ({ selectedResource, onActionStart, onActionUpdate, onAction
               </button>
             )}
 
-            {selectedResource && selectedResource.type === ResourceType.ECS && (
+            {selectedResource && !selectedResource.is_shared && selectedResource.type === ResourceType.ECS && (
               <button
                 onClick={() => setShowECSEditor(true)}
                 className="btn btn-configure"
@@ -712,7 +729,7 @@ const ActionPanel = ({ selectedResource, onActionStart, onActionUpdate, onAction
               </button>
             )}
 
-            {selectedResource && selectedResource.type === ResourceType.EC2 && selectedResource.id === 'ec2_datadog_docker' && (
+            {selectedResource && !selectedResource.is_shared && selectedResource.type === ResourceType.EC2 && selectedResource.id === 'ec2_datadog_docker' && (
               <button
                 onClick={() => setShowDockerAgentEditor(true)}
                 className="btn btn-configure"
@@ -724,7 +741,7 @@ const ActionPanel = ({ selectedResource, onActionStart, onActionUpdate, onAction
           </div>
         </div>
 
-        {selectedResource?.type !== ResourceType.EKS && selectedResource?.type !== ResourceType.ECS && (
+        {!selectedResource?.is_shared && selectedResource?.type !== ResourceType.EKS && selectedResource?.type !== ResourceType.ECS && (
           <div className="action-section variables-section">
             <div className="section-header-flex">
               <h3>Resource Variables</h3>
@@ -956,6 +973,8 @@ const ActionPanel = ({ selectedResource, onActionStart, onActionUpdate, onAction
         <EKSManageModal
           onClose={() => { setShowEKSManageModal(false); setEksConnectInfo(null); }}
           connectInfo={eksConnectInfo}
+          sharedClusterName={selectedResource?.is_shared ? selectedResource.name : undefined}
+          sharedOwnerPrefix={selectedResource?.is_shared ? selectedResource.shared_from : undefined}
         />
       )}
       {showECSEditor && createPortal(

--- a/webui/frontend/src/components/ClusterShareModal.tsx
+++ b/webui/frontend/src/components/ClusterShareModal.tsx
@@ -1,0 +1,325 @@
+import { useState, useEffect, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import { clusterShareApi } from '../services/api';
+import { EKSClusterInfo, ClusterShareRequest } from '../types';
+import '../styles/ClusterShareModal.css';
+
+interface ClusterShareModalProps {
+  onClose: () => void;
+  onSharedClustersChanged?: () => void;
+}
+
+type TabId = 'request' | 'manage';
+
+const ClusterShareModal = ({ onClose, onSharedClustersChanged }: ClusterShareModalProps) => {
+  const [activeTab, setActiveTab] = useState<TabId>('request');
+  const [clusters, setClusters] = useState<EKSClusterInfo[]>([]);
+  const [myPrefix, setMyPrefix] = useState('');
+  const [clustersLoading, setClustersLoading] = useState(false);
+  const [incoming, setIncoming] = useState<ClusterShareRequest[]>([]);
+  const [outgoing, setOutgoing] = useState<ClusterShareRequest[]>([]);
+  const [requestsLoading, setRequestsLoading] = useState(false);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const loadClusters = useCallback(async () => {
+    setClustersLoading(true);
+    setError(null);
+    try {
+      const data = await clusterShareApi.listClusters();
+      setClusters(data.clusters);
+      setMyPrefix(data.my_prefix);
+    } catch (err: any) {
+      setError(err?.response?.data?.detail || 'Failed to load EKS clusters');
+    } finally {
+      setClustersLoading(false);
+    }
+  }, []);
+
+  const loadRequests = useCallback(async () => {
+    setRequestsLoading(true);
+    setError(null);
+    try {
+      const [inc, out] = await Promise.all([
+        clusterShareApi.getIncomingRequests(),
+        clusterShareApi.getOutgoingRequests(),
+      ]);
+      setIncoming(inc);
+      setOutgoing(out);
+    } catch (err: any) {
+      setError(err?.response?.data?.detail || 'Failed to load requests');
+    } finally {
+      setRequestsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (activeTab === 'request') loadClusters();
+    else loadRequests();
+  }, [activeTab, loadClusters, loadRequests]);
+
+  useEffect(() => {
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleEsc);
+    return () => document.removeEventListener('keydown', handleEsc);
+  }, [onClose]);
+
+  const handleRequestShare = async (cluster: EKSClusterInfo) => {
+    if (!cluster.owner_prefix) {
+      setError('Cannot determine cluster owner');
+      return;
+    }
+    setActionLoading(cluster.arn);
+    setError(null);
+    setSuccess(null);
+    try {
+      await clusterShareApi.createRequest(cluster.name, cluster.arn, cluster.owner_prefix);
+      setSuccess(`Share request sent for ${cluster.name}`);
+      setTimeout(() => setSuccess(null), 3000);
+    } catch (err: any) {
+      setError(err?.response?.data?.detail || 'Failed to send share request');
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleApprove = async (requestId: string) => {
+    setActionLoading(requestId);
+    setError(null);
+    try {
+      await clusterShareApi.approveRequest(requestId);
+      await loadRequests();
+      onSharedClustersChanged?.();
+      setSuccess('Request approved');
+      setTimeout(() => setSuccess(null), 3000);
+    } catch (err: any) {
+      setError(err?.response?.data?.detail || 'Failed to approve request');
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleDeny = async (requestId: string) => {
+    setActionLoading(requestId);
+    setError(null);
+    try {
+      await clusterShareApi.denyRequest(requestId);
+      await loadRequests();
+      setSuccess('Request denied');
+      setTimeout(() => setSuccess(null), 3000);
+    } catch (err: any) {
+      setError(err?.response?.data?.detail || 'Failed to deny request');
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleDelete = async (requestId: string) => {
+    setActionLoading(requestId);
+    setError(null);
+    try {
+      await clusterShareApi.deleteRequest(requestId);
+      await loadRequests();
+      onSharedClustersChanged?.();
+      setSuccess('Request deleted');
+      setTimeout(() => setSuccess(null), 3000);
+    } catch (err: any) {
+      setError(err?.response?.data?.detail || 'Failed to delete request');
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const statusBadge = (status: string) => {
+    const cls = status === 'approved' ? 'badge-approved' : status === 'denied' ? 'badge-denied' : 'badge-pending';
+    return <span className={`cs-badge ${cls}`}>{status}</span>;
+  };
+
+  const renderRequestTab = () => (
+    <div className="cs-tab-content">
+      <p className="cs-description">
+        All EKS clusters in the current region are listed. Only clusters created by DogSTAC are available for sharing.
+      </p>
+      {clustersLoading ? (
+        <div className="cs-loading">Loading EKS clusters...</div>
+      ) : clusters.length === 0 ? (
+        <div className="cs-empty">No EKS clusters found in this AWS account.</div>
+      ) : (
+        <div className="cs-cluster-list">
+          {clusters.map(cluster => (
+            <div key={cluster.arn} className="cs-cluster-item">
+              <div className="cs-cluster-info">
+                <div className="cs-cluster-name">{cluster.name}</div>
+                <div className="cs-cluster-meta">
+                  <span className={`cs-cluster-status ${cluster.status === 'ACTIVE' ? 'active' : ''}`}>
+                    {cluster.status}
+                  </span>
+                  {cluster.owner_prefix && (
+                    <span className="cs-cluster-owner">Owner: {cluster.owner_prefix}</span>
+                  )}
+                </div>
+                <div className="cs-cluster-arn">{cluster.arn}</div>
+              </div>
+              {cluster.owner_prefix === myPrefix ? (
+                <span className="cs-own-label">Your cluster</span>
+              ) : (
+                <button
+                  className="btn btn-deploy cs-request-btn"
+                  onClick={() => handleRequestShare(cluster)}
+                  disabled={actionLoading === cluster.arn || !cluster.owner_prefix}
+                  title={!cluster.owner_prefix ? 'Cannot determine owner' : 'Request cluster share'}
+                >
+                  {actionLoading === cluster.arn ? 'Sending...' : 'Request Share'}
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+
+  const pendingIncoming = incoming.filter(r => r.status === 'pending');
+  const resolvedIncoming = incoming.filter(r => r.status !== 'pending');
+
+  const renderManageTab = () => (
+    <div className="cs-tab-content">
+      <div className="cs-section">
+        <h3>Incoming Requests {pendingIncoming.length > 0 && <span className="cs-count">{pendingIncoming.length}</span>}</h3>
+        {requestsLoading ? (
+          <div className="cs-loading">Loading requests...</div>
+        ) : pendingIncoming.length === 0 && resolvedIncoming.length === 0 ? (
+          <div className="cs-empty">No incoming requests.</div>
+        ) : (
+          <div className="cs-request-list">
+            {pendingIncoming.map(req => (
+              <div key={req.id} className="cs-request-item">
+                <div className="cs-request-info">
+                  <div className="cs-request-title">
+                    <strong>{req.requester_prefix}</strong> wants to share <strong>{req.cluster_name}</strong>
+                  </div>
+                  <div className="cs-request-meta">
+                    {statusBadge(req.status)} &middot; {new Date(req.created_at).toLocaleDateString()}
+                  </div>
+                </div>
+                <div className="cs-request-actions">
+                  <button
+                    className="btn btn-deploy cs-action-btn"
+                    onClick={() => handleApprove(req.id)}
+                    disabled={actionLoading === req.id}
+                  >
+                    {actionLoading === req.id ? '...' : 'Approve'}
+                  </button>
+                  <button
+                    className="btn btn-destroy cs-action-btn"
+                    onClick={() => handleDeny(req.id)}
+                    disabled={actionLoading === req.id}
+                  >
+                    {actionLoading === req.id ? '...' : 'Deny'}
+                  </button>
+                </div>
+              </div>
+            ))}
+            {resolvedIncoming.map(req => (
+              <div key={req.id} className="cs-request-item resolved">
+                <div className="cs-request-info">
+                  <div className="cs-request-title">
+                    <strong>{req.requester_prefix}</strong> &mdash; <strong>{req.cluster_name}</strong>
+                  </div>
+                  <div className="cs-request-meta">
+                    {statusBadge(req.status)} &middot; {new Date(req.updated_at).toLocaleDateString()}
+                  </div>
+                </div>
+                <button
+                  className="btn cs-action-btn cs-delete-btn"
+                  onClick={() => handleDelete(req.id)}
+                  disabled={actionLoading === req.id}
+                  title="Remove this request"
+                >
+                  {actionLoading === req.id ? '...' : 'Remove'}
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="cs-section">
+        <h3>My Outgoing Requests</h3>
+        {requestsLoading ? (
+          <div className="cs-loading">Loading...</div>
+        ) : outgoing.length === 0 ? (
+          <div className="cs-empty">No outgoing requests.</div>
+        ) : (
+          <div className="cs-request-list">
+            {outgoing.map(req => (
+              <div key={req.id} className="cs-request-item">
+                <div className="cs-request-info">
+                  <div className="cs-request-title">
+                    <strong>{req.cluster_name}</strong> from <strong>{req.owner_prefix}</strong>
+                  </div>
+                  <div className="cs-request-meta">
+                    {statusBadge(req.status)} &middot; {new Date(req.created_at).toLocaleDateString()}
+                  </div>
+                </div>
+                {req.status === 'pending' && (
+                  <button
+                    className="btn cs-action-btn cs-delete-btn"
+                    onClick={() => handleDelete(req.id)}
+                    disabled={actionLoading === req.id}
+                    title="Cancel this request"
+                  >
+                    {actionLoading === req.id ? '...' : 'Cancel'}
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  return createPortal(
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-content cs-modal" onClick={e => e.stopPropagation()}>
+        <div className="cs-header">
+          <h2>Cluster Share</h2>
+          <button className="cs-close" onClick={onClose}>&times;</button>
+        </div>
+
+        <div className="cs-tabs">
+          <button
+            className={`cs-tab ${activeTab === 'request' ? 'active' : ''}`}
+            onClick={() => setActiveTab('request')}
+          >
+            Request Share
+          </button>
+          <button
+            className={`cs-tab ${activeTab === 'manage' ? 'active' : ''}`}
+            onClick={() => setActiveTab('manage')}
+          >
+            Manage Requests
+            {pendingIncoming.length > 0 && <span className="cs-tab-badge">{pendingIncoming.length}</span>}
+          </button>
+        </div>
+
+        {(error || success) && (
+          <div className={`cs-alert ${error ? 'cs-alert-error' : 'cs-alert-success'}`}>
+            {error || success}
+          </div>
+        )}
+
+        <div className="cs-body">
+          {activeTab === 'request' ? renderRequestTab() : renderManageTab()}
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default ClusterShareModal;

--- a/webui/frontend/src/components/EKSManageModal.tsx
+++ b/webui/frontend/src/components/EKSManageModal.tsx
@@ -9,7 +9,7 @@ import {
   SortableContext, useSortable, verticalListSortingStrategy, arrayMove,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { eksManageApi, EKSPreset, TreeNode, TreeFolder, DeploymentInfo } from '../services/api';
+import { eksManageApi, clusterShareApi, EKSPreset, TreeNode, TreeFolder, DeploymentInfo } from '../services/api';
 import '../styles/EKSManageModal.css';
 
 interface EKSManageModalProps {
@@ -19,6 +19,8 @@ interface EKSManageModalProps {
     clusterName: string;
     ssoCommand: string;
   } | null;
+  sharedClusterName?: string;
+  sharedOwnerPrefix?: string;
 }
 
 type TabId = 'connection' | 'presets' | 'editor' | 'deploy' | 'run';
@@ -87,7 +89,8 @@ const RootDropZone = ({ id }: { id: string }) => {
   );
 };
 
-const EKSManageModal = ({ onClose, connectInfo }: EKSManageModalProps) => {
+const EKSManageModal = ({ onClose, connectInfo, sharedClusterName, sharedOwnerPrefix }: EKSManageModalProps) => {
+  const isShared = !!sharedClusterName;
   const [activeTab, setActiveTab] = useState<TabId>(connectInfo ? 'connection' : 'presets');
   const [presets, setPresets] = useState<EKSPreset[]>([]);
   const [loadingPresets, setLoadingPresets] = useState(false);
@@ -126,6 +129,14 @@ const EKSManageModal = ({ onClose, connectInfo }: EKSManageModalProps) => {
   const [runHistoryIdx, setRunHistoryIdx] = useState(-1);
   const credErrorRef = useRef(false);
 
+  const [sharedPresets, setSharedPresets] = useState<EKSPreset[]>([]);
+  const [presetSource, setPresetSource] = useState<'my' | 'shared' | 'connected'>('my');
+  const [editorIsShared, setEditorIsShared] = useState(false);
+  const [connectedUsers, setConnectedUsers] = useState<string[]>([]);
+  const [selectedConnectedUser, setSelectedConnectedUser] = useState('');
+  const [connectedPresets, setConnectedPresets] = useState<EKSPreset[]>([]);
+  const [connectedOwnerPrefix, setConnectedOwnerPrefix] = useState('');
+
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [createName, setCreateName] = useState('');
   const [createDesc, setCreateDesc] = useState('');
@@ -138,12 +149,20 @@ const EKSManageModal = ({ onClose, connectInfo }: EKSManageModalProps) => {
 
   const loadDeployments = useCallback(async () => {
     try {
-      const data = await eksManageApi.getDeployments();
-      setDeployedPresets(data);
+      if (isShared && sharedOwnerPrefix) {
+        const [myData, sharedData] = await Promise.all([
+          eksManageApi.getDeployments(),
+          eksManageApi.listSharedDeployments(sharedOwnerPrefix),
+        ]);
+        setDeployedPresets({ ...sharedData, ...myData });
+      } else {
+        const data = await eksManageApi.getDeployments();
+        setDeployedPresets(data);
+      }
     } catch (e) {
       console.error('Failed to load deployments:', e);
     }
-  }, []);
+  }, [isShared, sharedOwnerPrefix]);
 
   const loadPresets = useCallback(async () => {
     setLoadingPresets(true);
@@ -168,7 +187,27 @@ const EKSManageModal = ({ onClose, connectInfo }: EKSManageModalProps) => {
 
   useEffect(() => {
     loadPresets();
-  }, [loadPresets]);
+    if (isShared && sharedOwnerPrefix) {
+      eksManageApi.listSharedPresets(sharedOwnerPrefix)
+        .then(data => setSharedPresets(data.presets))
+        .catch(e => console.error('Failed to load shared presets:', e));
+    }
+    if (!isShared) {
+      clusterShareApi.getConnectedUsers()
+        .then(users => {
+          setConnectedUsers(users);
+          if (users.length > 0) setSelectedConnectedUser(users[0]);
+        })
+        .catch(e => console.error('Failed to load connected users:', e));
+    }
+  }, [loadPresets, isShared, sharedOwnerPrefix]);
+
+  useEffect(() => {
+    if (!selectedConnectedUser) { setConnectedPresets([]); return; }
+    eksManageApi.listSharedPresets(selectedConnectedUser)
+      .then(data => setConnectedPresets(data.presets))
+      .catch(e => console.error('Failed to load connected user presets:', e));
+  }, [selectedConnectedUser]);
 
   useEffect(() => {
     if (presets.length === 0) return;
@@ -188,6 +227,8 @@ const EKSManageModal = ({ onClose, connectInfo }: EKSManageModalProps) => {
     }
     setEditorPreset(name);
     setDeployPreset(name);
+    setEditorIsShared(false);
+    setConnectedOwnerPrefix('');
     localStorage.setItem(STORAGE_KEY, name);
     setEditorActiveFile('');
     setEditorContent('');
@@ -206,6 +247,90 @@ const EKSManageModal = ({ onClose, connectInfo }: EKSManageModalProps) => {
       }
     } catch (e) {
       console.error('Failed to load preset for editing:', e);
+    }
+  };
+
+  const handleSelectSharedPreset = async (name: string) => {
+    if (!sharedOwnerPrefix) return;
+    if (editorDirty || cmdDirty || editorDescDirty) {
+      if (!window.confirm('Unsaved changes will be lost. Continue?')) return;
+    }
+    setEditorPreset(name);
+    setDeployPreset(name);
+    setEditorIsShared(true);
+    localStorage.setItem(STORAGE_KEY, name);
+    setEditorActiveFile('');
+    setEditorContent('');
+    setEditorDirty(false);
+    setCmdDirty(false);
+    setEditorDescDirty(false);
+    try {
+      const preset = await eksManageApi.getSharedPreset(name, sharedOwnerPrefix);
+      setEditorDescription(preset.description || '');
+      setEditorFiles(preset.files || []);
+      setCmdDeploy((preset.deploy_commands || []).join('\n'));
+      setCmdUpdate((preset.update_commands || []).join('\n'));
+      setCmdUndeploy((preset.undeploy_commands || []).join('\n'));
+      if (preset.files?.length > 0) {
+        await loadSharedFile(name, preset.files[0]);
+      }
+    } catch (e) {
+      console.error('Failed to load shared preset for editing:', e);
+    }
+  };
+
+  const loadSharedFile = async (preset: string, filename: string) => {
+    const prefix = sharedOwnerPrefix || connectedOwnerPrefix;
+    if (!prefix) return;
+    try {
+      const { content } = await eksManageApi.getSharedPresetFile(preset, filename, prefix);
+      setEditorActiveFile(filename);
+      setEditorContent(content);
+      setEditorDirty(false);
+    } catch (e) {
+      console.error('Failed to load shared file:', e);
+      setEditorContent(`Error loading file: ${filename}`);
+    }
+  };
+
+  const handleSelectConnectedPreset = async (name: string, userPrefix: string) => {
+    if (editorDirty || cmdDirty || editorDescDirty) {
+      if (!window.confirm('Unsaved changes will be lost. Continue?')) return;
+    }
+    setEditorPreset(name);
+    setDeployPreset(name);
+    setEditorIsShared(true);
+    setConnectedOwnerPrefix(userPrefix);
+    localStorage.setItem(STORAGE_KEY, name);
+    setEditorActiveFile('');
+    setEditorContent('');
+    setEditorDirty(false);
+    setCmdDirty(false);
+    setEditorDescDirty(false);
+    try {
+      const preset = await eksManageApi.getSharedPreset(name, userPrefix);
+      setEditorDescription(preset.description || '');
+      setEditorFiles(preset.files || []);
+      setCmdDeploy((preset.deploy_commands || []).join('\n'));
+      setCmdUpdate((preset.update_commands || []).join('\n'));
+      setCmdUndeploy((preset.undeploy_commands || []).join('\n'));
+      if (preset.files?.length > 0) {
+        await loadConnectedFile(name, preset.files[0], userPrefix);
+      }
+    } catch (e) {
+      console.error('Failed to load connected user preset:', e);
+    }
+  };
+
+  const loadConnectedFile = async (preset: string, filename: string, userPrefix: string) => {
+    try {
+      const { content } = await eksManageApi.getSharedPresetFile(preset, filename, userPrefix);
+      setEditorActiveFile(filename);
+      setEditorContent(content);
+      setEditorDirty(false);
+    } catch (e) {
+      console.error('Failed to load connected user file:', e);
+      setEditorContent(`Error loading file: ${filename}`);
     }
   };
 
@@ -239,7 +364,11 @@ const EKSManageModal = ({ onClose, connectInfo }: EKSManageModalProps) => {
     if (editorDirty) {
       if (!window.confirm('Unsaved changes will be lost. Continue?')) return;
     }
-    await loadFile(editorPreset, filename);
+    if (editorIsShared) {
+      await loadSharedFile(editorPreset, filename);
+    } else {
+      await loadFile(editorPreset, filename);
+    }
   };
 
   const handleSaveFile = async () => {
@@ -345,6 +474,12 @@ const EKSManageModal = ({ onClose, connectInfo }: EKSManageModalProps) => {
     }
   };
 
+  const getOwnerPrefixForDeploy = (): string | undefined => {
+    if (isShared) return sharedOwnerPrefix;
+    if (connectedOwnerPrefix) return connectedOwnerPrefix;
+    return undefined;
+  };
+
   const handleDeploy = async () => {
     if (!deployPreset || deploying) return;
     setDeploying(true);
@@ -357,6 +492,8 @@ const EKSManageModal = ({ onClose, connectInfo }: EKSManageModalProps) => {
         deployPreset, onStreamChunk,
         (success) => onStreamDone(success, { onSuccess: loadDeployments }),
         abortRef.current.signal,
+        sharedClusterName,
+        getOwnerPrefixForDeploy(),
       );
     } catch (e) {
       setDeployStatus('error');
@@ -378,6 +515,8 @@ const EKSManageModal = ({ onClose, connectInfo }: EKSManageModalProps) => {
         deployPreset, onStreamChunk,
         (success) => onStreamDone(success, { onSuccess: loadDeployments }),
         abortRef.current.signal,
+        sharedClusterName,
+        getOwnerPrefixForDeploy(),
       );
     } catch (e) {
       setDeployStatus('error');
@@ -398,6 +537,8 @@ const EKSManageModal = ({ onClose, connectInfo }: EKSManageModalProps) => {
         deployPreset, onStreamChunk,
         (success) => onStreamDone(success),
         abortRef.current.signal,
+        sharedClusterName,
+        getOwnerPrefixForDeploy(),
       );
     } catch (e) {
       setDeployStatus('error');
@@ -555,6 +696,26 @@ const EKSManageModal = ({ onClose, connectInfo }: EKSManageModalProps) => {
   };
 
   const renderConnectionTab = () => {
+    if (isShared) {
+      return (
+        <div className="eks-connect-section">
+          <div className="eks-connect-field">
+            <label>Shared Cluster</label>
+            <div className="eks-connect-value-row">
+              <code>{sharedClusterName}</code>
+              <button className="eks-copy-btn" onClick={() => copyToClipboard(sharedClusterName || '')}>Copy</button>
+            </div>
+          </div>
+          <div className="eks-connect-field">
+            <label>Owner</label>
+            <code>{sharedOwnerPrefix}</code>
+          </div>
+          <div className="hint" style={{ marginTop: 8 }}>
+            Kubeconfig is automatically configured when you use the Run or Deploy tabs.
+          </div>
+        </div>
+      );
+    }
     if (!connectInfo) {
       return (
         <div className="eks-manage-loading">
@@ -629,6 +790,92 @@ const EKSManageModal = ({ onClose, connectInfo }: EKSManageModalProps) => {
     if (loadingPresets) {
       return <div className="eks-manage-loading">Loading presets...</div>;
     }
+
+    if (isShared && presetSource === 'shared') {
+      return (
+        <div>
+          <div className="eks-presets-toolbar">
+            <div className="eks-preset-source-toggle">
+              <button className="" onClick={() => setPresetSource('my')}>My Presets</button>
+              <button className="active" onClick={() => setPresetSource('shared')}>Shared Presets</button>
+            </div>
+          </div>
+          {sharedPresets.length === 0 ? (
+            <div className="eks-manage-loading">No shared presets from {sharedOwnerPrefix}.</div>
+          ) : (
+            <div className="eks-tree">
+              {sharedPresets.map(p => (
+                <div
+                  key={p.name}
+                  className={`eks-tree-preset ${editorPreset === p.name && editorIsShared ? 'selected' : ''}`}
+                  onClick={() => { handleSelectSharedPreset(p.name); setActiveTab('editor'); }}
+                >
+                  <span className="eks-tree-preset-name">{p.name}</span>
+                  <span className={`eks-preset-badge ${p.built_in ? 'built-in' : 'custom'}`}>
+                    {p.built_in ? 'OOTB' : 'Custom'}
+                  </span>
+                  <span className="eks-tree-preset-desc">{p.description}</span>
+                  <span className="eks-tree-actions">
+                    <button onClick={(e) => { e.stopPropagation(); setDeployPreset(p.name); localStorage.setItem(STORAGE_KEY, p.name); setActiveTab('deploy'); }}>Deploy</button>
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    if (!isShared && connectedUsers.length > 0 && presetSource === 'connected') {
+      return (
+        <div>
+          <div className="eks-presets-toolbar">
+            <div className="eks-preset-source-toggle">
+              <button className="" onClick={() => setPresetSource('my')}>My Presets</button>
+              <button className="active" onClick={() => setPresetSource('connected')}>Connected Presets</button>
+            </div>
+            <select
+              className="eks-connected-user-select"
+              value={selectedConnectedUser}
+              onChange={e => setSelectedConnectedUser(e.target.value)}
+            >
+              {connectedUsers.map(u => (
+                <option key={u} value={u}>{u}</option>
+              ))}
+            </select>
+          </div>
+          {connectedPresets.length === 0 ? (
+            <div className="eks-manage-loading">No presets from {selectedConnectedUser}.</div>
+          ) : (
+            <div className="eks-tree">
+              {connectedPresets.map(p => (
+                <div
+                  key={p.name}
+                  className={`eks-tree-preset ${editorPreset === p.name && editorIsShared ? 'selected' : ''}`}
+                  onClick={() => { handleSelectConnectedPreset(p.name, selectedConnectedUser); setActiveTab('editor'); }}
+                >
+                  <span className="eks-tree-preset-name">{p.name}</span>
+                  <span className={`eks-preset-badge ${p.built_in ? 'built-in' : 'custom'}`}>
+                    {p.built_in ? 'OOTB' : 'Custom'}
+                  </span>
+                  <span className="eks-tree-preset-desc">{p.description}</span>
+                  <span className="eks-tree-actions">
+                    <button onClick={(e) => {
+                      e.stopPropagation();
+                      setDeployPreset(p.name);
+                      setConnectedOwnerPrefix(selectedConnectedUser);
+                      localStorage.setItem(STORAGE_KEY, p.name);
+                      setActiveTab('deploy');
+                    }}>Deploy</button>
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      );
+    }
+
     return (
       <DndContext
         sensors={dndSensors}
@@ -638,6 +885,18 @@ const EKSManageModal = ({ onClose, connectInfo }: EKSManageModalProps) => {
         onDragEnd={handleTreeDragEnd}
       >
         <div className="eks-presets-toolbar">
+          {isShared && (
+            <div className="eks-preset-source-toggle">
+              <button className={presetSource === 'my' ? 'active' : ''} onClick={() => setPresetSource('my')}>My Presets</button>
+              <button className={presetSource === 'shared' ? 'active' : ''} onClick={() => setPresetSource('shared')}>Shared Presets</button>
+            </div>
+          )}
+          {!isShared && connectedUsers.length > 0 && (
+            <div className="eks-preset-source-toggle">
+              <button className={presetSource === 'my' ? 'active' : ''} onClick={() => setPresetSource('my')}>My Presets</button>
+              <button className={presetSource === 'connected' ? 'active' : ''} onClick={() => setPresetSource('connected')}>Connected Presets</button>
+            </div>
+          )}
           <button className="eks-btn-create" onClick={() => setShowCreateForm(!showCreateForm)}>
             {showCreateForm ? 'Cancel' : '+ New Preset'}
           </button>
@@ -722,14 +981,14 @@ const EKSManageModal = ({ onClose, connectInfo }: EKSManageModalProps) => {
       );
     }
 
-    const readonly = isOotb(editorPreset);
+    const readonly = isOotb(editorPreset) || editorIsShared;
 
     return (
       <div className="eks-editor-layout">
         <div className="eks-editor-sidebar">
           <div className="eks-editor-sidebar-title">
             {editorPreset}
-            {readonly && <span className="eks-ootb-badge">OOTB</span>}
+            {editorIsShared ? <span className="eks-ootb-badge">Shared</span> : readonly && <span className="eks-ootb-badge">OOTB</span>}
           </div>
           <div className="eks-editor-description-field">
             <input
@@ -910,6 +1169,7 @@ const EKSManageModal = ({ onClose, connectInfo }: EKSManageModalProps) => {
           }
         },
         runAbortRef.current.signal,
+        sharedClusterName,
       );
     } catch (e) {
       setRunStatus('error');
@@ -1028,10 +1288,29 @@ const EKSManageModal = ({ onClose, connectInfo }: EKSManageModalProps) => {
         )}
         <div className="eks-deploy-preset-select">
           <label>Preset</label>
-          <select value={deployPreset} onChange={e => { setDeployPreset(e.target.value); localStorage.setItem(STORAGE_KEY, e.target.value); }} disabled={deploying}>
+          <select value={deployPreset} onChange={e => {
+            const val = e.target.value;
+            setDeployPreset(val);
+            setConnectedOwnerPrefix(connectedPresets.some(p => p.name === val) ? selectedConnectedUser : '');
+            localStorage.setItem(STORAGE_KEY, val);
+          }} disabled={deploying}>
             {presets.map(p => (
               <option key={p.name} value={p.name}>{p.name}</option>
             ))}
+            {isShared && sharedPresets.length > 0 && (
+              <optgroup label={`Shared (${sharedOwnerPrefix})`}>
+                {sharedPresets.map(p => (
+                  <option key={`shared-${p.name}`} value={p.name}>{p.name}</option>
+                ))}
+              </optgroup>
+            )}
+            {!isShared && connectedPresets.length > 0 && (
+              <optgroup label={`Connected (${selectedConnectedUser})`}>
+                {connectedPresets.map(p => (
+                  <option key={`conn-${p.name}`} value={p.name}>{p.name}</option>
+                ))}
+              </optgroup>
+            )}
           </select>
         </div>
         <div className="eks-deploy-actions">
@@ -1055,7 +1334,10 @@ const EKSManageModal = ({ onClose, connectInfo }: EKSManageModalProps) => {
             onClick={async () => {
               if (!deployPreset) return;
               if (!window.confirm(`Force remove "${deployPreset}" from deployed list?\n(No undeploy commands will be executed)`)) return;
-              try { await eksManageApi.forceDelete(deployPreset); loadDeployments(); } catch {}
+              try {
+                await eksManageApi.forceDelete(deployPreset, getOwnerPrefixForDeploy(), sharedClusterName);
+                loadDeployments();
+              } catch {}
             }}
           >
             Force Delete
@@ -1082,7 +1364,7 @@ const EKSManageModal = ({ onClose, connectInfo }: EKSManageModalProps) => {
     <div className="modal-overlay" onClick={onClose}>
       <div className="eks-manage-modal" onClick={e => e.stopPropagation()}>
         <div className="eks-manage-header">
-          <h2>EKS Connect & Manage</h2>
+          <h2>{isShared ? `Shared EKS: ${sharedClusterName}` : 'EKS Connect & Manage'}</h2>
           <button className="eks-manage-close" onClick={onClose}>&times;</button>
         </div>
         <div className="eks-manage-tabs">

--- a/webui/frontend/src/components/ResourceSidebar.tsx
+++ b/webui/frontend/src/components/ResourceSidebar.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
-import { TerraformResource } from '../types';
-import { terraformApi } from '../services/api';
+import { TerraformResource, ResourceType, ResourceStatus, SharedCluster } from '../types';
+import { terraformApi, clusterShareApi } from '../services/api';
 
 interface ResourceSidebarProps {
   onResourceSelect: (resource: TerraformResource | null) => void;
@@ -8,10 +8,13 @@ interface ResourceSidebarProps {
   refreshTrigger?: number;
   runningResources?: Map<string, string>;
   onResourcesLoaded?: (resources: TerraformResource[]) => void;
+  onRequestClusterShare?: () => void;
+  sharedClusterRefreshTrigger?: number;
 }
 
-const ResourceSidebar = ({ onResourceSelect, selectedResourceId, refreshTrigger, runningResources, onResourcesLoaded }: ResourceSidebarProps) => {
+const ResourceSidebar = ({ onResourceSelect, selectedResourceId, refreshTrigger, runningResources, onResourcesLoaded, onRequestClusterShare, sharedClusterRefreshTrigger }: ResourceSidebarProps) => {
   const [resources, setResources] = useState<TerraformResource[]>([]);
+  const [sharedClusters, setSharedClusters] = useState<SharedCluster[]>([]);
   const [loading, setLoading] = useState(true);
   
   // Load expanded sections from localStorage or use defaults
@@ -59,8 +62,18 @@ const ResourceSidebar = ({ onResourceSelect, selectedResourceId, refreshTrigger,
     }
   };
 
+  const loadSharedClusters = async () => {
+    try {
+      const shared = await clusterShareApi.getSharedClusters();
+      setSharedClusters(shared);
+    } catch (err) {
+      console.error('Failed to load shared clusters:', err);
+    }
+  };
+
   useEffect(() => {
     loadResources(true);
+    loadSharedClusters();
   }, []);
 
   useEffect(() => {
@@ -68,6 +81,10 @@ const ResourceSidebar = ({ onResourceSelect, selectedResourceId, refreshTrigger,
       loadResources(false);
     }
   }, [refreshTrigger]);
+
+  useEffect(() => {
+    loadSharedClusters();
+  }, [sharedClusterRefreshTrigger]);
 
   const toggleSection = (type: string) => {
     const newExpanded = new Set(expandedSections);
@@ -179,6 +196,42 @@ const ResourceSidebar = ({ onResourceSelect, selectedResourceId, refreshTrigger,
                     </div>
                   </div>
                 ))}
+                {type === 'eks' && sharedClusters.map((sc) => {
+                  const sharedId = `shared-eks-${sc.cluster_arn}`;
+                  return (
+                    <div
+                      key={sharedId}
+                      className={`sidebar-item shared-item ${selectedResourceId === sharedId ? 'selected' : ''}`}
+                      onClick={() => onResourceSelect({
+                        id: sharedId,
+                        name: sc.cluster_name,
+                        type: ResourceType.EKS,
+                        file_path: `Shared from ${sc.owner_prefix}`,
+                        line_start: 0,
+                        line_end: 0,
+                        status: ResourceStatus.ENABLED,
+                        description: `Shared EKS Cluster: ${sc.owner_prefix}`,
+                        is_shared: true,
+                        shared_from: sc.owner_prefix,
+                      })}
+                    >
+                      <span className="item-status shared" />
+                      <div className="item-content">
+                        <div className="item-name">Shared EKS Cluster: {sc.owner_prefix}</div>
+                        <div className="item-file">{sc.cluster_name}</div>
+                      </div>
+                    </div>
+                  );
+                })}
+                {type === 'eks' && (
+                  <div
+                    className="sidebar-action-item"
+                    onClick={() => onRequestClusterShare?.()}
+                  >
+                    <span className="action-icon">🔗</span>
+                    <span className="action-label">Request Cluster Share</span>
+                  </div>
+                )}
               </div>
             )}
           </div>

--- a/webui/frontend/src/services/api.ts
+++ b/webui/frontend/src/services/api.ts
@@ -2,7 +2,10 @@ import axios from 'axios';
 import {
   TerraformResource,
   TerraformVariable,
-  ApiResponse
+  ApiResponse,
+  EKSClusterInfo,
+  ClusterShareRequest,
+  SharedCluster,
 } from '../types';
 
 const API_BASE_URL = '/api/terraform';
@@ -870,13 +873,48 @@ export const eksManageApi = {
     return response.data;
   },
 
+  listSharedPresets: async (ownerPrefix: string): Promise<{ presets: EKSPreset[] }> => {
+    const response = await axios.get<{ presets: EKSPreset[] }>(
+      `${EKS_MANAGE_BASE}/shared-presets`, { params: { owner_prefix: ownerPrefix } }
+    );
+    return response.data;
+  },
+
+  getSharedPreset: async (name: string, ownerPrefix: string): Promise<EKSPreset> => {
+    const response = await axios.get<EKSPreset>(
+      `${EKS_MANAGE_BASE}/shared-presets/${name}`, { params: { owner_prefix: ownerPrefix } }
+    );
+    return response.data;
+  },
+
+  getSharedPresetFile: async (name: string, filename: string, ownerPrefix: string): Promise<EKSPresetFileResponse> => {
+    const response = await axios.get<EKSPresetFileResponse>(
+      `${EKS_MANAGE_BASE}/shared-presets/${name}/files/${encodeURIComponent(filename)}`,
+      { params: { owner_prefix: ownerPrefix } }
+    );
+    return response.data;
+  },
+
+  listSharedDeployments: async (ownerPrefix: string): Promise<Record<string, DeploymentInfo>> => {
+    const response = await axios.get<{ deployments: Record<string, DeploymentInfo> }>(
+      `${EKS_MANAGE_BASE}/shared-deployments`, { params: { owner_prefix: ownerPrefix } }
+    );
+    return response.data.deployments;
+  },
+
   streamDeploy: async (
     name: string,
     onData: (chunk: string) => void,
     onComplete: (success: boolean) => void,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    clusterName?: string,
+    ownerPrefix?: string
   ): Promise<void> => {
-    const response = await fetch(`${EKS_MANAGE_BASE}/presets/${name}/deploy`, {
+    const qp = new URLSearchParams();
+    if (clusterName) qp.set('cluster_name', clusterName);
+    if (ownerPrefix) qp.set('owner_prefix', ownerPrefix);
+    const qs = qp.toString() ? `?${qp.toString()}` : '';
+    const response = await fetch(`${EKS_MANAGE_BASE}/presets/${name}/deploy${qs}`, {
       method: 'POST',
       signal,
     });
@@ -906,9 +944,15 @@ export const eksManageApi = {
     name: string,
     onData: (chunk: string) => void,
     onComplete: (success: boolean) => void,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    clusterName?: string,
+    ownerPrefix?: string
   ): Promise<void> => {
-    const response = await fetch(`${EKS_MANAGE_BASE}/presets/${name}/update`, {
+    const qp = new URLSearchParams();
+    if (clusterName) qp.set('cluster_name', clusterName);
+    if (ownerPrefix) qp.set('owner_prefix', ownerPrefix);
+    const qs = qp.toString() ? `?${qp.toString()}` : '';
+    const response = await fetch(`${EKS_MANAGE_BASE}/presets/${name}/update${qs}`, {
       method: 'POST',
       signal,
     });
@@ -938,9 +982,15 @@ export const eksManageApi = {
     name: string,
     onData: (chunk: string) => void,
     onComplete: (success: boolean) => void,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    clusterName?: string,
+    ownerPrefix?: string
   ): Promise<void> => {
-    const response = await fetch(`${EKS_MANAGE_BASE}/presets/${name}/undeploy`, {
+    const qp = new URLSearchParams();
+    if (clusterName) qp.set('cluster_name', clusterName);
+    if (ownerPrefix) qp.set('owner_prefix', ownerPrefix);
+    const qs = qp.toString() ? `?${qp.toString()}` : '';
+    const response = await fetch(`${EKS_MANAGE_BASE}/presets/${name}/undeploy${qs}`, {
       method: 'POST',
       signal,
     });
@@ -970,12 +1020,15 @@ export const eksManageApi = {
     command: string,
     onData: (chunk: string) => void,
     onComplete: (success: boolean) => void,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    clusterName?: string
   ): Promise<void> => {
+    const body: Record<string, string> = { command };
+    if (clusterName) body.cluster_name = clusterName;
     const response = await fetch(`${EKS_MANAGE_BASE}/kubectl`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ command }),
+      body: JSON.stringify(body),
       signal,
     });
     if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
@@ -1014,8 +1067,64 @@ export const eksManageApi = {
     await axios.put(`${EKS_MANAGE_BASE}/layout`, { layout });
   },
 
-  forceDelete: async (name: string): Promise<{ success: boolean }> => {
-    const response = await axios.post(`${EKS_MANAGE_BASE}/presets/${name}/force-delete`);
+  forceDelete: async (name: string, ownerPrefix?: string, clusterName?: string): Promise<{ success: boolean }> => {
+    const params: Record<string, string> = {};
+    if (ownerPrefix) params.owner_prefix = ownerPrefix;
+    if (clusterName) params.cluster_name = clusterName;
+    const response = await axios.post(`${EKS_MANAGE_BASE}/presets/${name}/force-delete`, null, { params });
     return response.data;
+  },
+};
+
+const CLUSTER_SHARE_BASE = '/api/cluster-share';
+
+export const clusterShareApi = {
+  listClusters: async (): Promise<{ clusters: EKSClusterInfo[]; my_prefix: string }> => {
+    const response = await axios.get<{ clusters: EKSClusterInfo[]; my_prefix: string }>(`${CLUSTER_SHARE_BASE}/clusters`);
+    return response.data;
+  },
+
+  createRequest: async (clusterName: string, clusterArn: string, ownerPrefix: string): Promise<ClusterShareRequest> => {
+    const response = await axios.post<ClusterShareRequest>(`${CLUSTER_SHARE_BASE}/requests`, {
+      cluster_name: clusterName,
+      cluster_arn: clusterArn,
+      owner_prefix: ownerPrefix,
+    });
+    return response.data;
+  },
+
+  getIncomingRequests: async (): Promise<ClusterShareRequest[]> => {
+    const response = await axios.get<{ requests: ClusterShareRequest[] }>(`${CLUSTER_SHARE_BASE}/requests/incoming`);
+    return response.data.requests;
+  },
+
+  getOutgoingRequests: async (): Promise<ClusterShareRequest[]> => {
+    const response = await axios.get<{ requests: ClusterShareRequest[] }>(`${CLUSTER_SHARE_BASE}/requests/outgoing`);
+    return response.data.requests;
+  },
+
+  approveRequest: async (requestId: string): Promise<ClusterShareRequest> => {
+    const response = await axios.post<ClusterShareRequest>(`${CLUSTER_SHARE_BASE}/requests/${requestId}/approve`);
+    return response.data;
+  },
+
+  denyRequest: async (requestId: string): Promise<ClusterShareRequest> => {
+    const response = await axios.post<ClusterShareRequest>(`${CLUSTER_SHARE_BASE}/requests/${requestId}/deny`);
+    return response.data;
+  },
+
+  getSharedClusters: async (): Promise<SharedCluster[]> => {
+    const response = await axios.get<{ clusters: SharedCluster[] }>(`${CLUSTER_SHARE_BASE}/shared`);
+    return response.data.clusters;
+  },
+
+  deleteRequest: async (requestId: string): Promise<{ success: boolean }> => {
+    const response = await axios.delete<{ success: boolean }>(`${CLUSTER_SHARE_BASE}/requests/${requestId}`);
+    return response.data;
+  },
+
+  getConnectedUsers: async (): Promise<string[]> => {
+    const response = await axios.get<{ users: string[] }>(`${CLUSTER_SHARE_BASE}/connected-users`);
+    return response.data.users;
   },
 };

--- a/webui/frontend/src/styles/App.css
+++ b/webui/frontend/src/styles/App.css
@@ -565,6 +565,42 @@ body.light-mode .section-header:hover {
   color: var(--text-secondary);
 }
 
+.sidebar-item.shared-item {
+  border-left-color: #3498db;
+}
+
+.item-status.shared {
+  background: #3498db;
+  box-shadow: 0 0 8px rgba(52, 152, 219, 0.6), 0 0 12px rgba(52, 152, 219, 0.4);
+}
+
+.sidebar-action-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  margin-top: 4px;
+  cursor: pointer;
+  font-size: 0.82rem;
+  color: var(--primary-color);
+  opacity: 0.85;
+  transition: all 0.2s;
+  border-radius: 6px;
+}
+
+.sidebar-action-item:hover {
+  opacity: 1;
+  background: rgba(139, 127, 199, 0.1);
+}
+
+.action-icon {
+  font-size: 0.85rem;
+}
+
+.action-label {
+  font-weight: 500;
+}
+
 /* Action Panel - Center */
 .action-panel {
   flex: 1;

--- a/webui/frontend/src/styles/ClusterShareModal.css
+++ b/webui/frontend/src/styles/ClusterShareModal.css
@@ -1,0 +1,343 @@
+.cs-modal {
+  background: var(--bg-primary);
+  width: 95%;
+  max-width: 800px;
+  max-height: 85vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+}
+
+.cs-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 24px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.cs-header h2 {
+  margin: 0;
+  font-size: 22px;
+  color: var(--text-primary);
+}
+
+.cs-close {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 24px;
+  cursor: pointer;
+  padding: 4px 8px;
+  line-height: 1;
+}
+
+.cs-close:hover {
+  color: var(--text-primary);
+}
+
+.cs-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 12px 24px 0;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+}
+
+.cs-tab {
+  padding: 10px 20px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  transition: all 0.2s;
+  border-bottom: 2px solid transparent;
+  position: relative;
+}
+
+.cs-tab:hover {
+  background: rgba(139, 127, 199, 0.1);
+  color: var(--text-primary);
+}
+
+.cs-tab.active {
+  background: var(--bg-primary);
+  color: var(--primary-color);
+  border-bottom: 2px solid var(--primary-color);
+}
+
+.cs-tab-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #e74c3c;
+  color: white;
+  font-size: 11px;
+  font-weight: 600;
+  min-width: 18px;
+  height: 18px;
+  border-radius: 9px;
+  padding: 0 5px;
+  margin-left: 6px;
+}
+
+.cs-alert {
+  padding: 10px 24px;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.cs-alert-error {
+  background: rgba(231, 76, 60, 0.15);
+  color: #e74c3c;
+}
+
+.cs-alert-success {
+  background: rgba(46, 204, 113, 0.15);
+  color: #2ecc71;
+}
+
+.cs-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px;
+  min-height: 300px;
+}
+
+.cs-body::-webkit-scrollbar {
+  width: 8px;
+}
+
+.cs-body::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.cs-body::-webkit-scrollbar-thumb {
+  background: var(--border-color);
+  border-radius: 4px;
+}
+
+.cs-description {
+  color: var(--text-secondary);
+  font-size: 13px;
+  margin: 0 0 16px;
+  line-height: 1.5;
+}
+
+.cs-loading {
+  text-align: center;
+  padding: 40px 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.cs-empty {
+  text-align: center;
+  padding: 40px 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+  opacity: 0.7;
+}
+
+.cs-cluster-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.cs-cluster-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  transition: border-color 0.2s;
+}
+
+.cs-cluster-item:hover {
+  border-color: var(--primary-color);
+}
+
+.cs-cluster-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.cs-cluster-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 4px;
+}
+
+.cs-cluster-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 2px;
+}
+
+.cs-cluster-status {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  padding: 1px 6px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 3px;
+}
+
+.cs-cluster-status.active {
+  color: #2ecc71;
+  background: rgba(46, 204, 113, 0.15);
+}
+
+.cs-cluster-owner {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.cs-cluster-arn {
+  font-size: 11px;
+  color: var(--text-secondary);
+  opacity: 0.6;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cs-request-btn {
+  flex-shrink: 0;
+  margin-left: 12px;
+  font-size: 12px;
+  padding: 6px 14px;
+}
+
+.cs-section {
+  margin-bottom: 28px;
+}
+
+.cs-section h3 {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.cs-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--primary-color);
+  color: white;
+  font-size: 11px;
+  font-weight: 600;
+  min-width: 20px;
+  height: 20px;
+  border-radius: 10px;
+  padding: 0 6px;
+}
+
+.cs-request-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.cs-request-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+}
+
+.cs-request-item.resolved {
+  opacity: 0.65;
+}
+
+.cs-request-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.cs-request-title {
+  font-size: 13px;
+  color: var(--text-primary);
+  margin-bottom: 3px;
+}
+
+.cs-request-meta {
+  font-size: 12px;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.cs-request-actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+  margin-left: 12px;
+}
+
+.cs-action-btn {
+  font-size: 12px !important;
+  padding: 5px 12px !important;
+}
+
+.cs-delete-btn {
+  background: transparent !important;
+  border: 1px solid var(--border-color) !important;
+  color: var(--text-secondary) !important;
+}
+
+.cs-delete-btn:hover {
+  border-color: #e74c3c !important;
+  color: #e74c3c !important;
+}
+
+.cs-badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  padding: 1px 8px;
+  border-radius: 3px;
+}
+
+.badge-pending {
+  background: rgba(241, 196, 15, 0.2);
+  color: #f1c40f;
+}
+
+.badge-approved {
+  background: rgba(46, 204, 113, 0.2);
+  color: #2ecc71;
+}
+
+.badge-denied {
+  background: rgba(231, 76, 60, 0.2);
+  color: #e74c3c;
+}
+
+.cs-own-label {
+  flex-shrink: 0;
+  margin-left: 12px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  opacity: 0.7;
+  padding: 6px 14px;
+}

--- a/webui/frontend/src/styles/EKSManageModal.css
+++ b/webui/frontend/src/styles/EKSManageModal.css
@@ -154,7 +154,83 @@
 .eks-presets-toolbar {
   display: flex;
   justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
   margin-bottom: 16px;
+}
+
+.eks-preset-source-toggle {
+  display: flex;
+  gap: 2px;
+  margin-right: auto;
+  background: var(--bg-secondary);
+  border-radius: 6px;
+  padding: 2px;
+  border: 1px solid var(--border-color);
+}
+
+.eks-preset-source-toggle button {
+  padding: 5px 14px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: 4px;
+  transition: all 0.2s;
+}
+
+.eks-preset-source-toggle button.active {
+  background: var(--primary-color);
+  color: white;
+}
+
+.eks-preset-source-toggle button:hover:not(.active) {
+  color: var(--text-primary);
+}
+
+.eks-connected-user-select {
+  padding: 5px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 500;
+  margin-left: 8px;
+}
+
+.eks-shared-preset-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-top: 8px;
+}
+
+.eks-shared-preset-item {
+  padding: 10px 14px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: border-color 0.2s;
+}
+
+.eks-shared-preset-item:hover {
+  border-color: var(--primary-color);
+}
+
+.eks-shared-preset-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.eks-shared-preset-desc {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 2px;
 }
 
 .eks-btn-create {

--- a/webui/frontend/src/types/index.ts
+++ b/webui/frontend/src/types/index.ts
@@ -25,6 +25,8 @@ export interface TerraformResource {
   line_end: number;
   status: ResourceStatus;
   description?: string;
+  is_shared?: boolean;
+  shared_from?: string;
 }
 
 export interface TerraformVariable {
@@ -51,4 +53,29 @@ export interface ApiResponse {
   error?: string;
   message?: string;
   command?: string;
+}
+
+export interface EKSClusterInfo {
+  name: string;
+  arn: string;
+  status: string;
+  owner_prefix?: string;
+}
+
+export interface ClusterShareRequest {
+  id: string;
+  requester_prefix: string;
+  cluster_name: string;
+  cluster_arn: string;
+  owner_prefix: string;
+  status: 'pending' | 'approved' | 'denied';
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SharedCluster {
+  cluster_name: string;
+  cluster_arn: string;
+  owner_prefix: string;
+  shared_at: string;
 }


### PR DESCRIPTION

### Summary
Introduces **Cluster Share** so peer DogSTAC users in the same AWS account + region can request access to an EKS cluster, the owner can approve or deny, and approved users can manage workloads on that cluster with clear limits on infrastructure actions. State lives in **SSM Parameter Store**; presets and deployment metadata continue to use **S3** with correct **owner bucket discovery** via SSM when salt differs between users.
### User-facing behavior
- **Request Cluster Share** lists region EKS clusters; only clusters tagged **`ManagedBy = Terraform`** can be requested (others are visible but not actionable).
- **Manage requests** lets the owner approve or deny incoming requests; **self-share** is blocked.
- Approved clusters appear in the sidebar as **Shared EKS Cluster: &lt;owner prefix&gt;** with **Manage** enabled but **no Plan / Destroy / Configure cluster** for the shared resource.
- On a shared cluster, **Presets** split into **My Presets** and **Shared Presets** (owner’s S3); shared presets use the same card-style UI as local presets, **read-only** in the editor (like OOTB), and are selectable on **Deploy**.
- **Deployed** list merges the owner’s `_deployments.json` with the viewer’s local deployments where relevant.
- **Run (kubectl)** uses an explicit cluster name so kubeconfig is built correctly for shared clusters (fixes localhost:8080 errors).
- **Undeploy / force-delete** for shared flows update the **owner’s** `_deployments.json` when acting on the shared cluster; **OOTB** presets fall back to local manifest when absent in owner S3.
- **Force delete** and deploy paths pass **`owner_prefix`** consistently for shared clusters, including **OOTB** presets on shared clusters (`isShared`-based prefix, not “preset is in shared list”).
- **Owners** can open **Connected Presets**: list of **approved requesters**, per-user preset browsing (reuse shared-preset APIs with `owner_prefix`), read-only editor + deploy; deploy uses connected user’s bucket for **sync** while **deployment records** stay on the **owner’s** cluster when `cluster_name` is not the shared-cluster case (backend: remote `_deployments.json` only when both `owner_prefix` and `cluster_name` are set for shared-cluster operations).
### Backend (high level)
- New **`cluster_share`** routes and **`ClusterShareManager`** (list clusters, create/approve/deny/delete requests, shared clusters, **`GET /connected-users`**).
- **`eks_manage`**: `_discover_owner_bucket`, shared preset/deployment endpoints, `_resolve_preset` OOTB fallback, `_owner_mark_deployed` / `_owner_mark_undeployed`, **`upload_text`** on S3 client, stream actions with **`cluster_name`** / **`owner_prefix`**, shared sync fallback to local for OOTB.
- **`instances/eks-cluster`**: align with **ManagedBy = Terraform** tagging expectations (no ad-hoc DogSTAC-only tag).
### Frontend (high level)
- Types and **`clusterShareApi`** / **`eksManageApi`** extensions.
- **`ClusterShareModal`**, sidebar and **`ActionPanel`** integration, **`EKSManageModal`** shared + connected flows, styles as added.
### Notes for reviewers
- IAM must allow SSM read/write under the cluster-share prefix and S3 access to peer buckets as required by your account policy.
- Rebuild/restart the stack after pulling so backend and frontend changes are aligned.