### PR TITLE
feat: Send Feedback flow + FAB/Danger Zone UX

### DIFF
--- a/webui/backend/app/services/container_logs.py
+++ b/webui/backend/app/services/container_logs.py
@@ -1,0 +1,62 @@
+import asyncio
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TAIL = 500
+MAX_TAIL = 5000
+MAX_BYTES = 512_000
+
+
+def _resolve_container_id() -> str | None:
+    override = os.environ.get("DOCKER_LOGS_CONTAINER", "").strip()
+    if override:
+        return override
+    try:
+        return Path("/etc/hostname").read_text(encoding="utf-8").strip() or None
+    except OSError:
+        return None
+
+
+def _resolve_tail(requested: int) -> int:
+    env = os.environ.get("DOCKER_LOGS_TAIL", "").strip()
+    if env.isdigit():
+        n = int(env)
+    else:
+        n = requested
+    return max(1, min(n, MAX_TAIL))
+
+
+async def fetch_docker_logs_tail(lines: int = DEFAULT_TAIL) -> tuple[bool, str]:
+    container = _resolve_container_id()
+    if not container:
+        return False, "Could not resolve container id (set DOCKER_LOGS_CONTAINER or ensure /etc/hostname exists)"
+    tail = _resolve_tail(lines)
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "docker",
+            "logs",
+            "--tail",
+            str(tail),
+            container,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        out, _ = await asyncio.wait_for(proc.communicate(), timeout=90)
+        text = out.decode("utf-8", errors="replace")
+        if proc.returncode != 0:
+            logger.debug("docker logs rc=%s len=%s", proc.returncode, len(text))
+            return False, text.strip() or f"docker logs exited with code {proc.returncode}"
+        raw = text.encode("utf-8")
+        if len(raw) > MAX_BYTES:
+            text = raw[:MAX_BYTES].decode("utf-8", errors="ignore") + "\n... [truncated]\n"
+        return True, text
+    except FileNotFoundError:
+        return False, "docker CLI not found in container"
+    except asyncio.TimeoutError:
+        return False, "docker logs timed out"
+    except Exception as e:
+        logger.debug("fetch_docker_logs_tail failed: %s", e)
+        return False, str(e)

--- a/webui/frontend/src/App.tsx
+++ b/webui/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import ConnectionsModal from './components/ConnectionsModal';
 import OnboardingModal from './components/OnboardingModal';
 import DangerZoneModal from './components/DangerZoneModal';
 import SSOLoginModal from './components/SSOLoginModal';
+import FeedbackFab from './components/FeedbackFab';
 import { TerraformResource, ResourceType } from './types';
 import { terraformApi as api, OnboardingStatus } from './services/api';
 
@@ -107,6 +108,7 @@ function App() {
   const healthRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const [providerReady, setProviderReady] = useState<boolean | null>(null);
   const [providerProgress, setProviderProgress] = useState({ progress: 0, message: '' });
+  const [feedbackFabPulse, setFeedbackFabPulse] = useState(false);
 
   useEffect(() => {
     const savedTheme = localStorage.getItem('theme');
@@ -361,6 +363,12 @@ function App() {
               });
             },
             (success) => {
+              if (!success && action === 'destroy') {
+                setFeedbackFabPulse(true);
+              }
+              if (success && action === 'destroy') {
+                setFeedbackFabPulse(false);
+              }
               setResults(prev => {
                 const updated = [...prev];
                 const idx = updated.findIndex(r => r.id === resultId);
@@ -457,6 +465,13 @@ function App() {
   };
 
   const handleActionComplete = (id: string, success: boolean, action: string, resourceId?: string) => {
+    const a = action.toLowerCase();
+    if (!success && (a === 'plan' || a === 'destroy')) {
+      setFeedbackFabPulse(true);
+    }
+    if (success && (a === 'plan' || a === 'destroy')) {
+      setFeedbackFabPulse(false);
+    }
     setResults(prev => {
       const updated = [...prev];
       const index = updated.findIndex(r => r.id === id);
@@ -682,12 +697,24 @@ function App() {
         />
       )}
 
+      <FeedbackFab
+        selectedResourceId={selectedResource?.id ?? null}
+        latestResultAction={results[0]?.action ?? null}
+        latestResultStatus={results[0]?.status ?? null}
+        emphasizePulse={feedbackFabPulse}
+        onOpenModal={() => setFeedbackFabPulse(false)}
+      />
+
       <button
+        type="button"
         className="danger-zone-fab"
         onClick={() => setShowDangerZone(true)}
-        title="Danger Zone"
+        aria-label="Danger Zone"
       >
-        ⚠
+        <span className="danger-zone-fab-icon" aria-hidden>
+          ⚠
+        </span>
+        <span className="danger-zone-fab-label">Danger Zone</span>
       </button>
     </div>
   );

--- a/webui/frontend/src/components/FeedbackFab.css
+++ b/webui/frontend/src/components/FeedbackFab.css
@@ -1,0 +1,304 @@
+.feedback-fab {
+  position: fixed;
+  bottom: 84px;
+  right: 24px;
+  z-index: 1010;
+  width: 48px;
+  height: 48px;
+  padding: 0;
+  border-radius: 0;
+  border: 1px solid rgba(139, 127, 199, 0.45);
+  background: linear-gradient(135deg, rgba(139, 127, 199, 0.22) 0%, rgba(139, 127, 199, 0.1) 100%);
+  backdrop-filter: blur(12px) saturate(1.4);
+  -webkit-backdrop-filter: blur(12px) saturate(1.4);
+  box-shadow: 0 4px 20px rgba(139, 127, 199, 0.22), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  color: var(--primary-light, #a99fd4);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0;
+  transition: width 0.2s ease, gap 0.2s ease, padding 0.2s ease, background 0.2s ease, border-color 0.2s ease,
+    box-shadow 0.2s ease, color 0.2s ease;
+  overflow: hidden;
+  font-size: 14px;
+  font-weight: 600;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+}
+
+.feedback-fab:hover {
+  width: auto;
+  background: linear-gradient(135deg, rgba(139, 127, 199, 0.32) 0%, rgba(139, 127, 199, 0.16) 100%);
+  border-color: rgba(139, 127, 199, 0.65);
+  box-shadow: 0 6px 28px rgba(139, 127, 199, 0.38), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  gap: 8px;
+  padding: 0 14px;
+  color: #ffffff;
+}
+
+.feedback-fab:active {
+  box-shadow: 0 2px 12px rgba(139, 127, 199, 0.25);
+}
+
+.feedback-fab-label {
+  max-width: 0;
+  opacity: 0;
+  white-space: nowrap;
+  transition: max-width 0.2s ease, opacity 0.18s ease;
+}
+
+.feedback-fab:hover .feedback-fab-label {
+  max-width: 200px;
+  opacity: 1;
+}
+
+.feedback-fab-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.feedback-fab-pulse {
+  animation: feedback-fab-pulse 2s ease-in-out infinite;
+}
+
+@keyframes feedback-fab-pulse {
+  0%,
+  100% {
+    box-shadow: 0 4px 20px rgba(139, 127, 199, 0.22), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  }
+  50% {
+    box-shadow: 0 6px 28px rgba(139, 127, 199, 0.45), 0 0 0 4px rgba(139, 127, 199, 0.15),
+      inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  }
+}
+
+body.light-mode .feedback-fab {
+  color: #5a4a9e;
+  text-shadow: none;
+  background: linear-gradient(135deg, rgba(139, 127, 199, 0.14) 0%, rgba(139, 127, 199, 0.07) 100%);
+  border-color: rgba(139, 127, 199, 0.35);
+  box-shadow: 0 4px 20px rgba(139, 127, 199, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.5);
+}
+
+body.light-mode .feedback-fab:hover {
+  color: #352d6e;
+  background: linear-gradient(135deg, rgba(139, 127, 199, 0.22) 0%, rgba(139, 127, 199, 0.12) 100%);
+  border-color: rgba(139, 127, 199, 0.5);
+  box-shadow: 0 6px 28px rgba(139, 127, 199, 0.2);
+}
+
+.feedback-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100000;
+  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  animation: fadeIn 0.2s ease;
+}
+
+body.light-mode .feedback-modal-overlay {
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.feedback-modal {
+  width: 100%;
+  max-width: 520px;
+  max-height: min(90vh, 640px);
+  overflow: auto;
+  background: var(--card-bg);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border-radius: 0;
+  border: 2px solid var(--primary-color);
+  box-shadow: 0 25px 80px rgba(0, 0, 0, 0.6), 0 0 120px rgba(139, 127, 199, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.05);
+  display: flex;
+  flex-direction: column;
+  animation: fadeIn 0.2s ease;
+}
+
+body.light-mode .feedback-modal {
+  box-shadow: 0 25px 80px rgba(0, 0, 0, 0.15), 0 0 80px rgba(139, 127, 199, 0.25), 0 0 0 1px rgba(139, 127, 199, 0.12);
+}
+
+.feedback-modal-header {
+  padding: 1.5rem 1.5rem 0.75rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.feedback-modal-title {
+  margin: 0 0 8px;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--primary-color);
+}
+
+.feedback-modal-subtitle {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.45;
+  color: var(--text-secondary);
+}
+
+.feedback-modal-body {
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.feedback-modal-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.feedback-modal-section-label {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+  letter-spacing: 0.02em;
+}
+
+.feedback-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  font-family: inherit;
+  font-size: 0.95rem;
+  font-weight: 700;
+  cursor: pointer;
+  border-radius: 0;
+  padding: 0.85rem 1.25rem;
+  transition: all 0.2s ease;
+}
+
+.feedback-btn-primary {
+  background: linear-gradient(135deg, rgba(139, 127, 199, 0.5) 0%, rgba(139, 127, 199, 0.3) 100%);
+  border: 2px solid rgba(139, 127, 199, 0.6);
+  color: #ffffff;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 4px 15px rgba(139, 127, 199, 0.2);
+  align-self: flex-start;
+}
+
+.feedback-btn-primary:hover {
+  background: linear-gradient(135deg, rgba(139, 127, 199, 0.6) 0%, rgba(139, 127, 199, 0.35) 100%);
+  border-color: rgba(139, 127, 199, 0.85);
+  box-shadow: 0 8px 25px rgba(139, 127, 199, 0.35);
+  transform: translateY(-2px);
+}
+
+.feedback-btn-primary:active {
+  transform: translateY(0);
+  box-shadow: 0 2px 10px rgba(139, 127, 199, 0.25);
+}
+
+body.light-mode .feedback-btn-primary {
+  background: linear-gradient(135deg, rgba(139, 127, 199, 0.35) 0%, rgba(139, 127, 199, 0.18) 100%);
+  color: #352d6e;
+  text-shadow: none;
+  border-color: rgba(139, 127, 199, 0.55);
+}
+
+body.light-mode .feedback-btn-primary:hover {
+  background: linear-gradient(135deg, rgba(139, 127, 199, 0.45) 0%, rgba(139, 127, 199, 0.22) 100%);
+  color: #2a2358;
+}
+
+.feedback-btn-secondary {
+  background: var(--btn-glass-primary);
+  backdrop-filter: var(--glass-blur);
+  -webkit-backdrop-filter: var(--glass-blur);
+  border: 2px solid var(--btn-glass-border);
+  color: #ffffff;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+}
+
+.feedback-btn-secondary:hover {
+  background: var(--btn-glass-primary-hover);
+  border-color: var(--btn-glass-border-hover);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(139, 127, 199, 0.35);
+}
+
+.feedback-btn-secondary:active {
+  transform: translateY(0);
+}
+
+body.light-mode .feedback-btn-secondary {
+  color: #4a3f8a;
+  text-shadow: none;
+}
+
+body.light-mode .feedback-btn-secondary:hover {
+  color: #352d6e;
+}
+
+.feedback-modal-url-hint {
+  margin: 0;
+  font-size: 0.75rem;
+  word-break: break-all;
+  color: var(--text-tertiary);
+}
+
+.feedback-modal-contact-row {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--text-primary);
+}
+
+.feedback-modal-contact-key {
+  font-weight: 700;
+  color: var(--text-secondary);
+}
+
+.feedback-modal-link {
+  color: var(--primary-light);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.feedback-modal-link:hover {
+  color: var(--primary-color);
+}
+
+body.light-mode .feedback-modal-link {
+  color: var(--primary-dark);
+}
+
+body.light-mode .feedback-modal-link:hover {
+  color: #5a4a9e;
+}
+
+.feedback-modal-channel {
+  font-weight: 700;
+  font-family: ui-monospace, monospace;
+  color: var(--primary-color);
+}
+
+.feedback-modal-footer {
+  padding: 0.75rem 1.5rem 1.25rem;
+  display: flex;
+  justify-content: flex-end;
+  border-top: 1px solid var(--border-color);
+}
+
+@media (max-width: 560px) {
+  .feedback-modal {
+    max-width: none;
+  }
+
+  .feedback-modal-overlay {
+    padding: 1rem;
+  }
+}

--- a/webui/frontend/src/components/FeedbackFab.tsx
+++ b/webui/frontend/src/components/FeedbackFab.tsx
@@ -1,0 +1,101 @@
+import { useState, useMemo, useCallback } from 'react';
+import FeedbackModal from './FeedbackModal';
+import './FeedbackFab.css';
+
+const GITHUB_NEW_ISSUE = 'https://github.com/chanhyeokseo/dogstac/issues/new';
+
+export interface FeedbackFabProps {
+  selectedResourceId: string | null;
+  latestResultAction: string | null;
+  latestResultStatus: 'running' | 'success' | 'error' | null;
+  emphasizePulse: boolean;
+  onOpenModal: () => void;
+}
+
+const MessageIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="22"
+    height="22"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden
+  >
+    <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+  </svg>
+);
+
+function buildGithubNewIssueUrl(
+  selectedResourceId: string | null,
+  latestResultAction: string | null,
+  latestResultStatus: string | null,
+): string {
+  const ts = new Date().toISOString();
+  const title = `[DogSTAC] Feedback`;
+  const lines = [
+    '## Context (auto-filled)',
+    `- Selected resource: ${selectedResourceId || 'none'}`,
+    `- Latest panel action: ${latestResultAction || 'none'}`,
+    `- Latest panel status: ${latestResultStatus || 'none'}`,
+    `- Timestamp: ${ts}`,
+    '',
+    '## Description',
+    '',
+  ];
+  const body = lines.join('\n');
+  const params = new URLSearchParams({ title, body });
+  return `${GITHUB_NEW_ISSUE}?${params.toString()}`;
+}
+
+const FeedbackFab = ({
+  selectedResourceId,
+  latestResultAction,
+  latestResultStatus,
+  emphasizePulse,
+  onOpenModal,
+}: FeedbackFabProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const githubNewIssueUrl = useMemo(
+    () => buildGithubNewIssueUrl(selectedResourceId, latestResultAction, latestResultStatus),
+    [selectedResourceId, latestResultAction, latestResultStatus],
+  );
+
+  const open = useCallback(() => {
+    if (import.meta.env.DEV) {
+      console.debug('[FeedbackFab] open modal', {
+        selectedResourceId,
+        latestResultAction,
+        latestResultStatus,
+      });
+    }
+    onOpenModal();
+    setIsOpen(true);
+  }, [onOpenModal, selectedResourceId, latestResultAction, latestResultStatus]);
+
+  const close = useCallback(() => setIsOpen(false), []);
+
+  return (
+    <>
+      <button
+        type="button"
+        className={`feedback-fab${emphasizePulse ? ' feedback-fab-pulse' : ''}`}
+        onClick={open}
+        aria-label="Send Feedback"
+        title={emphasizePulse ? 'Report an issue' : 'Send Feedback'}
+      >
+        <span className="feedback-fab-icon" aria-hidden>
+          <MessageIcon />
+        </span>
+        <span className="feedback-fab-label">Send Feedback</span>
+      </button>
+      <FeedbackModal isOpen={isOpen} onClose={close} githubNewIssueUrl={githubNewIssueUrl} />
+    </>
+  );
+};
+
+export default FeedbackFab;

--- a/webui/frontend/src/components/FeedbackModal.tsx
+++ b/webui/frontend/src/components/FeedbackModal.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+
+const GITHUB_REPO_ISSUES = 'https://github.com/chanhyeokseo/dogstac/issues';
+const FEEDBACK_EMAIL = 'chanhyeok.seo@datadoghq.com';
+
+export interface FeedbackModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  githubNewIssueUrl: string;
+}
+
+const FOCUSABLE =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+const FeedbackModal = ({ isOpen, onClose, githubNewIssueUrl }: FeedbackModalProps) => {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const getFocusable = useCallback(() => {
+    const root = panelRef.current;
+    if (!root) return [] as HTMLElement[];
+    return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE));
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (import.meta.env.DEV) {
+      console.debug('[FeedbackModal] open', { githubNewIssueUrlLength: githubNewIssueUrl.length });
+    }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      const list = getFocusable();
+      if (list.length === 0) return;
+      const first = list[0];
+      const last = list[list.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey) {
+        if (active === first || !panelRef.current?.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    const t = window.setTimeout(() => getFocusable()[0]?.focus(), 0);
+    return () => {
+      window.clearTimeout(t);
+      document.removeEventListener('keydown', onKeyDown);
+      if (import.meta.env.DEV) console.debug('[FeedbackModal] close');
+    };
+  }, [isOpen, onClose, getFocusable, githubNewIssueUrl]);
+
+  const onOverlayMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div
+      className="feedback-modal-overlay"
+      role="presentation"
+      onMouseDown={onOverlayMouseDown}
+    >
+      <div
+        ref={panelRef}
+        className="feedback-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="feedback-modal-title"
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <div className="feedback-modal-header">
+          <h2 id="feedback-modal-title" className="feedback-modal-title">
+            Send Feedback
+          </h2>
+          <p className="feedback-modal-subtitle">
+            Have feedback, bugs, or suggestions? We&apos;d love to hear from you.
+          </p>
+        </div>
+        <div className="feedback-modal-body">
+          <section className="feedback-modal-section" aria-label="GitHub">
+            <p className="feedback-modal-section-label">Create an issue on GitHub:</p>
+            <a
+              href={githubNewIssueUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="feedback-btn feedback-btn-primary"
+            >
+              Open GitHub Issues
+            </a>
+            <p className="feedback-modal-url-hint">{GITHUB_REPO_ISSUES}</p>
+          </section>
+          <section className="feedback-modal-section" aria-label="Direct contact">
+            <p className="feedback-modal-section-label">Or contact directly:</p>
+            <p className="feedback-modal-contact-row">
+              <span className="feedback-modal-contact-key">Email:</span>{' '}
+              <a className="feedback-modal-link" href={`mailto:${FEEDBACK_EMAIL}`}>
+                {FEEDBACK_EMAIL}
+              </a>
+            </p>
+            <p className="feedback-modal-contact-row">
+              <span className="feedback-modal-contact-key">Slack:</span> Reach out via Slack.
+            </p>
+          </section>
+        </div>
+        <div className="feedback-modal-footer">
+          <button type="button" className="feedback-btn feedback-btn-secondary" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+};
+
+export default FeedbackModal;

--- a/webui/frontend/src/components/OnboardingPage.tsx
+++ b/webui/frontend/src/components/OnboardingPage.tsx
@@ -556,11 +556,15 @@ function OnboardingPage() {
       )}
 
       <button
+        type="button"
         className="danger-zone-fab"
         onClick={() => setShowDangerZone(true)}
-        title="Danger Zone"
+        aria-label="Danger Zone"
       >
-        ⚠
+        <span className="danger-zone-fab-icon" aria-hidden>
+          ⚠
+        </span>
+        <span className="danger-zone-fab-label">Danger Zone</span>
       </button>
     </div>
   );

--- a/webui/frontend/src/styles/DangerZone.css
+++ b/webui/frontend/src/styles/DangerZone.css
@@ -5,6 +5,7 @@
   z-index: 1000;
   width: 48px;
   height: 48px;
+  padding: 0;
   border-radius: 0;
   border: 1px solid rgba(239, 83, 80, 0.4);
   background: linear-gradient(135deg, rgba(239, 83, 80, 0.15) 0%, rgba(239, 83, 80, 0.08) 100%);
@@ -13,31 +14,63 @@
   box-shadow: 0 4px 20px rgba(239, 83, 80, 0.2),
               inset 0 1px 0 rgba(255, 255, 255, 0.05);
   color: #ef5350;
-  font-size: 20px;
+  font-size: 14px;
+  font-weight: 600;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: all 0.2s ease;
+  gap: 0;
+  overflow: hidden;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+  transition: width 0.2s ease, gap 0.2s ease, padding 0.2s ease, background 0.2s ease, border-color 0.2s ease,
+    box-shadow 0.2s ease, color 0.2s ease;
 }
 
 .danger-zone-fab:hover {
+  width: auto;
   background: linear-gradient(135deg, rgba(239, 83, 80, 0.25) 0%, rgba(239, 83, 80, 0.15) 100%);
   border-color: rgba(239, 83, 80, 0.6);
   box-shadow: 0 6px 28px rgba(239, 83, 80, 0.35);
-  transform: translateY(-2px);
+  gap: 8px;
+  padding: 0 14px;
+  color: #ff8a80;
+}
+
+.danger-zone-fab-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  font-size: 20px;
+  line-height: 1;
+}
+
+.danger-zone-fab-label {
+  max-width: 0;
+  opacity: 0;
+  white-space: nowrap;
+  transition: max-width 0.2s ease, opacity 0.18s ease;
+}
+
+.danger-zone-fab:hover .danger-zone-fab-label {
+  max-width: 220px;
+  opacity: 1;
 }
 
 body.light-mode .danger-zone-fab {
   background: linear-gradient(135deg, rgba(239, 83, 80, 0.1) 0%, rgba(239, 83, 80, 0.05) 100%);
   border-color: rgba(239, 83, 80, 0.3);
   box-shadow: 0 4px 20px rgba(239, 83, 80, 0.1);
+  text-shadow: none;
+  color: #d32f2f;
 }
 
 body.light-mode .danger-zone-fab:hover {
   background: linear-gradient(135deg, rgba(239, 83, 80, 0.2) 0%, rgba(239, 83, 80, 0.1) 100%);
   border-color: rgba(239, 83, 80, 0.5);
   box-shadow: 0 6px 28px rgba(239, 83, 80, 0.2);
+  color: #c62828;
 }
 
 .danger-zone-modal {


### PR DESCRIPTION
## Summary

- Add a fixed Send Feedback control (bottom-right, above Danger Zone) that opens a modal with GitHub (prefilled new-issue URL), email (mailto), and Slack guidance (#dogstac-support).
- Match existing DogSTAC glass / square-corner styling; remove hover “float” (translateY) on both FABs.
- Danger Zone FAB now expands on hover to show Danger Zone, same pattern as Send Feedback.
- Optional: subtle pulse + “Report an issue” tooltip hint after Plan/Destroy failure; pulse clears when opening feedback.